### PR TITLE
Ikke send varsel til NL hvis moteplanlegger er brukt for sykmeldt

### DIFF
--- a/nais.yaml
+++ b/nais.yaml
@@ -75,6 +75,8 @@ fasitResources:
     resourceType: restservice
   - alias: syfomoteadminapi
     resourceType: restservice
+  - alias: syfosyketilfelleApi
+    resourceType: restservice
   - alias: aad_b2c_clientid
     resourceType: credential
     propertyMap:

--- a/src/main/java/no/nav/syfo/controller/VarselController.java
+++ b/src/main/java/no/nav/syfo/controller/VarselController.java
@@ -32,7 +32,9 @@ public class VarselController {
     public Response sendVarselNaermesteLeder(
             @RequestBody MotebehovsvarVarselInfo motebehovsvarVarselInfo
     ) {
+        log.info("L-TRACE: Fikk kall fra syfoservice om sending av varsel til NL");
         varselService.sendVarselTilNaermesteLeder(motebehovsvarVarselInfo);
+        log.info("L-TRACE: Ferdig med å sende varsel, sender ok til syfoservice");
 
         return Response
                 .ok()

--- a/src/main/java/no/nav/syfo/domain/rest/OppfolgingstilfelleDTO.java
+++ b/src/main/java/no/nav/syfo/domain/rest/OppfolgingstilfelleDTO.java
@@ -1,0 +1,12 @@
+package no.nav.syfo.domain.rest;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(fluent = true, chain = true)
+public class OppfolgingstilfelleDTO {
+    public int antallBrukteDager;
+    public boolean oppbruktArbeidsgvierperiode;
+    public PeriodeDTO arbeidsgiverperiode;
+}

--- a/src/main/java/no/nav/syfo/domain/rest/PeriodeDTO.java
+++ b/src/main/java/no/nav/syfo/domain/rest/PeriodeDTO.java
@@ -1,0 +1,13 @@
+package no.nav.syfo.domain.rest;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.time.LocalDate;
+
+@Data
+@Accessors(fluent = true, chain = true)
+public class PeriodeDTO {
+    public LocalDate fom;
+    public LocalDate tom;
+}

--- a/src/main/java/no/nav/syfo/service/MoterService.java
+++ b/src/main/java/no/nav/syfo/service/MoterService.java
@@ -1,10 +1,16 @@
 package no.nav.syfo.service;
 
 import lombok.extern.slf4j.Slf4j;
+import no.nav.syfo.domain.rest.OppfolgingstilfelleDTO;
+import no.nav.syfo.domain.rest.PeriodeDTO;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import static java.util.Optional.ofNullable;
 import static org.springframework.web.util.UriComponentsBuilder.fromHttpUrl;
 
 @Service
@@ -24,19 +30,27 @@ public class MoterService {
         this.syfomoteadminUrl = syfomoteadminUrl;
     }
 
-    boolean harArbeidstakerMoteIOppfolgingstilfelle(String aktorId) {
+    boolean erMoteOpprettetForArbeidstakerEtterDato(String aktorId, OppfolgingstilfelleDTO oppfolgingstilfelle) {
+        log.info("L-TRACE: Spørr syfomtoeadmin om mote er opprettet etter dato");
         String url = fromHttpUrl(syfomoteadminUrl)
                 .pathSegment("system", aktorId, "harAktivtMote")
                 .toUriString();
+        log.info("L-TRACE: Kall til syfomoteadmin med url: {}", url);
+
+        PeriodeDTO periode = oppfolgingstilfelle.arbeidsgiverperiode;
+        LocalDateTime startDato = LocalDateTime.of(periode.fom, LocalTime.MIN);
+        log.info("L-TRACE: Kall til syfomoteadmin med dato: {}", startDato);
 
         try {
-            Boolean harMoteIOppfolgingstilfellet = template.getForObject(url, Boolean.class);
-            if (harMoteIOppfolgingstilfellet != null) {
-                return harMoteIOppfolgingstilfellet;
-            } else {
+            Boolean erMoteOpprettetEtterDato = template.postForObject(url, startDato, Boolean.class);
+            if (!ofNullable(erMoteOpprettetEtterDato).isPresent()) {
+                log.info("L-TRACE: Fikk null fra syfomoteadmin");
                 throw new RuntimeException(SYFOMOTEADMIN_FEILMELDING_NULL);
             }
+            log.info("L-TRACE: Fikk erMoteOpprettet: {}", erMoteOpprettetEtterDato);
+            return erMoteOpprettetEtterDato;
         } catch (Exception e) {
+            log.info("L-TRACE: Fikk exception fra syfomoteadmin! ", e);
             log.error("Det skjedde en feil ved henting av om det er mote i oppfolgingstilfelle fra syfomoteadmin");
             throw new RuntimeException(SYFOMOTEADMIN_FEILMELDING_GENERELL, e);
         }

--- a/src/main/java/no/nav/syfo/service/SyketilfelleService.java
+++ b/src/main/java/no/nav/syfo/service/SyketilfelleService.java
@@ -1,0 +1,45 @@
+package no.nav.syfo.service;
+
+import lombok.extern.slf4j.Slf4j;
+import no.nav.syfo.domain.rest.OppfolgingstilfelleDTO;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import javax.inject.Inject;
+
+import static org.springframework.web.util.UriComponentsBuilder.fromHttpUrl;
+
+@Slf4j
+@Service
+public class SyketilfelleService {
+
+    private RestTemplate restTemplate;
+    private String syfosyketilfelleUrl;
+
+    @Inject
+    public SyketilfelleService(
+            RestTemplate restTemplate,
+            @Value("${syfosyketilfelleApi.url}") String syfosyketilfelleUrl
+    ) {
+        this.restTemplate = restTemplate;
+        this.syfosyketilfelleUrl = syfosyketilfelleUrl;
+    }
+
+
+    public OppfolgingstilfelleDTO hentNyesteOppfolgingstilfelle(String aktorId) {
+        log.info("L-TRACE: Skal hente oppfolgingstilfelle fra syfosyketilfelle");
+        String url = fromHttpUrl(syfosyketilfelleUrl)
+                .pathSegment("oppfolgingstilfelle", "beregn", "syfomotebehov", aktorId)
+                .toUriString();
+        log.info("L-TRACE: Henter oppfolgingstilfelle med url: {}", url);
+
+        try {
+            return restTemplate.getForObject(url, OppfolgingstilfelleDTO.class);
+        } catch (Exception e) {
+            log.info("L-TRACE: Fikk exception fra syfosyketilfelle!", e);
+            log.error("Det skjedde en feil ved henting av oppfolgingstilfelle fra syfosyketilfelle");
+            throw new RuntimeException("Klarte ikke hente oppfolgingstilfelle fra syfosyketilfelle", e);
+        }
+    }
+}

--- a/src/main/java/no/nav/syfo/service/VarselService.java
+++ b/src/main/java/no/nav/syfo/service/VarselService.java
@@ -2,6 +2,7 @@ package no.nav.syfo.service;
 
 import lombok.extern.slf4j.Slf4j;
 import no.nav.syfo.domain.rest.MotebehovsvarVarselInfo;
+import no.nav.syfo.domain.rest.OppfolgingstilfelleDTO;
 import no.nav.syfo.kafka.producer.TredjepartsvarselProducer;
 import no.nav.syfo.kafka.producer.model.KTredjepartsvarsel;
 import org.springframework.stereotype.Service;
@@ -10,6 +11,7 @@ import javax.inject.Inject;
 import java.util.UUID;
 
 import static java.time.LocalDateTime.now;
+import static java.util.Optional.ofNullable;
 import static no.nav.syfo.kafka.producer.VarselType.NAERMESTE_LEDER_SVAR_MOTEBEHOV;
 
 @Service
@@ -17,23 +19,38 @@ import static no.nav.syfo.kafka.producer.VarselType.NAERMESTE_LEDER_SVAR_MOTEBEH
 public class VarselService {
 
     private MoterService moterService;
+    private SyketilfelleService syketilfelleService;
     private TredjepartsvarselProducer tredjepartsvarselProducer;
 
     @Inject
     public VarselService(
             MoterService moterService,
+            SyketilfelleService syketilfelleService,
             TredjepartsvarselProducer tredjepartsvarselProducer) {
         this.moterService = moterService;
+        this.syketilfelleService = syketilfelleService;
         this.tredjepartsvarselProducer = tredjepartsvarselProducer;
     }
 
     public void sendVarselTilNaermesteLeder(MotebehovsvarVarselInfo motebehovsvarVarselInfo) {
-        if (!moterService.harArbeidstakerMoteIOppfolgingstilfelle(motebehovsvarVarselInfo.sykmeldtAktorId)) {
+        OppfolgingstilfelleDTO oppfolgingstilfelle = syketilfelleService.hentNyesteOppfolgingstilfelle(motebehovsvarVarselInfo.sykmeldtAktorId);
+        log.info("L-TRACE: Fikk oppfolgingstilfelle: {}", oppfolgingstilfelle);
+
+        if (!ofNullable(oppfolgingstilfelle).isPresent() || !ofNullable(oppfolgingstilfelle.arbeidsgiverperiode).isPresent()) {
+            log.info("L-TRACE: Fikk ikke oppfolgingstilfelle!");
+            log.error("Fant ikke oppfolgingstilfelle hos syfosyketilfelle, dette skal ikke skje, da syfoservice har sagt at motebehov-varsel skal sendes!");
+            throw new NullPointerException("Fikk ikke oppfolgingstilfelle fra syfosyketilfelle, dette skal ikke skje!");
+        }
+
+        if (!moterService.erMoteOpprettetForArbeidstakerEtterDato(motebehovsvarVarselInfo.sykmeldtAktorId, oppfolgingstilfelle)) {
+            log.info("L-TRACE: Mote er ikke opprettet etter dato, sender varsel!");
             log.info("Sender varsel til naermeste leder");
             KTredjepartsvarsel kTredjepartsvarsel = mapTilKTredjepartsvarsel(motebehovsvarVarselInfo);
             tredjepartsvarselProducer.sendTredjepartsvarselvarsel(kTredjepartsvarsel);
+        } else {
+            log.info("L-TRACE: Mote er opprettet etter dato, sender ikke varsel!");
+            log.info("Sender ikke varsel til naermeste leder fordi moteplanleggeren er brukt i oppfolgingstilfellet");
         }
-        log.info("Sender ikke varsel til naermeste leder fordi moteplanleggeren er brukt i oppfolgingstilfellet");
     }
 
     private KTredjepartsvarsel mapTilKTredjepartsvarsel(MotebehovsvarVarselInfo motebehovsvarVarselInfo) {

--- a/src/test/java/no/nav/syfo/service/MoterServiceTest.java
+++ b/src/test/java/no/nav/syfo/service/MoterServiceTest.java
@@ -1,5 +1,7 @@
 package no.nav.syfo.service;
 
+import no.nav.syfo.domain.rest.OppfolgingstilfelleDTO;
+import no.nav.syfo.domain.rest.PeriodeDTO;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -9,6 +11,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -26,6 +31,13 @@ public class MoterServiceTest {
     private MoterService moterService;
 
     private final String AKTOR_ID = "123";
+    private final OppfolgingstilfelleDTO TILFELLE = new OppfolgingstilfelleDTO()
+            .antallBrukteDager(120)
+            .oppbruktArbeidsgvierperiode(true)
+            .arbeidsgiverperiode(new PeriodeDTO()
+                    .fom(LocalDate.now().minusDays(119))
+                    .tom(LocalDate.now().plusDays(1)));
+
 
     @Before
     public void setUp() {
@@ -34,29 +46,29 @@ public class MoterServiceTest {
 
     @Test
     public void harArbeidstakerMoteIOppfolgingstilfelle_skal_returnere_true_hvis_moteplanlegger_er_brukt() {
-        when(template.getForObject(anyString(), any())).thenReturn(true);
+        when(template.postForObject(anyString(), any(LocalDateTime.class), any())).thenReturn(true);
 
-        assertTrue(moterService.harArbeidstakerMoteIOppfolgingstilfelle(AKTOR_ID));
+        assertTrue(moterService.erMoteOpprettetForArbeidstakerEtterDato(AKTOR_ID, TILFELLE));
     }
 
     @Test
     public void harArbeidstakerMoteIOppfolgingstilfelle_skal_returnere_false_hvis_moteplanlegger_ikke_er_brukt() {
-        when(template.getForObject(anyString(), any())).thenReturn(false);
+        when(template.postForObject(anyString(), any(LocalDateTime.class), any())).thenReturn(false);
 
-        assertFalse(moterService.harArbeidstakerMoteIOppfolgingstilfelle(AKTOR_ID));
+        assertFalse(moterService.erMoteOpprettetForArbeidstakerEtterDato(AKTOR_ID, TILFELLE));
     }
 
     @Test(expected = RuntimeException.class)
     public void harArbeidstakerMoteIOppfolgingstilfelle_skal_kaste_exception_hvis_svar_fra_syfomoteadmin_er_null() {
-        when(template.getForObject(anyString(), any())).thenReturn(null);
+        when(template.postForObject(anyString(), any(LocalDateTime.class), any())).thenReturn(null);
 
-        moterService.harArbeidstakerMoteIOppfolgingstilfelle(AKTOR_ID);
+        moterService.erMoteOpprettetForArbeidstakerEtterDato(AKTOR_ID, TILFELLE);
     }
 
     @Test(expected = RuntimeException.class)
     public void harArbeidstakerMoteIOppfolgingstilfelle_skal_kaste_exception_hvis_kall_til_syfomoteadmin_feiler() {
-        when(template.getForObject(anyString(), any())).thenReturn(HttpStatus.INTERNAL_SERVER_ERROR);
+        when(template.postForObject(anyString(), any(LocalDateTime.class), any())).thenReturn(HttpStatus.INTERNAL_SERVER_ERROR);
 
-        moterService.harArbeidstakerMoteIOppfolgingstilfelle(AKTOR_ID);
+        moterService.erMoteOpprettetForArbeidstakerEtterDato(AKTOR_ID, TILFELLE);
     }
 }

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -74,3 +74,4 @@ syfoveilederoppgaver.systemapi.password: "test123"
 
 tilgangskontrollapi.url: "https://www.ikke.no"
 syfomoteadminapi.url: "https://www.kanskje.no"
+syfosyketilfelleApi.url: http://localhost:8080


### PR DESCRIPTION
Gjør kall til syfomoteadmin for å sjekke om det finnes møte i det nåværende oppfølgingstifellet.
Hvis det ikke finnes møte, send varsel.
Hvis det finnes møte, ikke send varsel, men send OK til syfoservice slik at den ikke prøver igjen hele tiden.