### PR TITLE
Set version of oauth2-oidc-sdk explicitly

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ object Versions {
     const val junitJupiterVersion = "5.6.0"
     const val kotlinJacksonVersion = "2.9.8"
     const val flywayVersion = "5.1.4"
+    const val nimbusSDKVersion = "7.0.3"
     const val oidcSupportVersion = "0.2.18"
     const val ojdbcVersion = "19.3.0.0"
 }
@@ -57,6 +58,7 @@ dependencies {
 
     implementation("io.micrometer:micrometer-registry-prometheus:1.0.6")
 
+    implementation("com.nimbusds:oauth2-oidc-sdk:${Versions.nimbusSDKVersion}")
     implementation("no.nav.security:oidc-spring-support:${Versions.oidcSupportVersion}")
 
     implementation("com.oracle.ojdbc:ojdbc8:${Versions.ojdbcVersion}")


### PR DESCRIPTION
This is to prevent open ended range import of nimbus-jose-jwt and automatic import of faulty version.