### PR TITLE
Use motebehovUUID as Kafka message key

### DIFF
--- a/src/main/kotlin/no/nav/syfo/motebehov/database/MotebehovDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/database/MotebehovDAO.kt
@@ -35,9 +35,16 @@ class MotebehovDAO(private val namedParameterJdbcTemplate: NamedParameterJdbcTem
         return Optional.ofNullable(jdbcTemplate.query("SELECT * FROM motebehov WHERE aktoer_id = ? AND opprettet_av != ? AND virksomhetsnummer = ? AND opprettet_dato >= ? ORDER BY opprettet_dato DESC", innsendingRowMapper, arbeidstakerAktorId, arbeidstakerAktorId, virksomhetsnummer, hentTidligsteDatoForGyldigMotebehovSvar())).orElse(emptyList())
     }
 
-    fun oppdaterUbehandledeMotebehovTilBehandlet(aktoerId: String, veilederIdent: String): Int {
-        val oppdaterSql = "UPDATE motebehov SET behandlet_tidspunkt = ?, behandlet_veileder_ident = ? WHERE aktoer_id = ? AND har_motebehov = 1 AND behandlet_veileder_ident IS NULL"
-        return jdbcTemplate.update(oppdaterSql, convert(LocalDateTime.now()), veilederIdent, aktoerId)
+    fun hentUbehandledeMotebehov(aktoerId: String): List<PMotebehov> {
+        return Optional.ofNullable(jdbcTemplate.query("WHERE aktoer_id = ? AND har_motebehov = 1 AND behandlet_veileder_ident IS NULL", innsendingRowMapper, aktoerId)).orElse(emptyList())
+    }
+
+    fun oppdaterUbehandledeMotebehovTilBehandlet(
+        motebehovUUID: UUID,
+        veilederIdent: String
+    ): Int {
+        val oppdaterSql = "UPDATE motebehov SET behandlet_tidspunkt = ?, behandlet_veileder_ident = ? WHERE motebehov_uuid = ? AND har_motebehov = 1 AND behandlet_veileder_ident IS NULL"
+        return jdbcTemplate.update(oppdaterSql, convert(LocalDateTime.now()), veilederIdent, motebehovUUID.toString())
     }
 
     fun create(motebehov: PMotebehov): UUID {

--- a/src/main/kotlin/no/nav/syfo/oversikthendelse/OversikthendelseProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/oversikthendelse/OversikthendelseProducer.kt
@@ -10,11 +10,14 @@ import javax.inject.Inject
 class OversikthendelseProducer @Inject constructor(
     private val kafkaTemplate: KafkaTemplate<String, Any>
 ) {
-    fun sendOversikthendelse(kOversikthendelse: KOversikthendelse) {
+    fun sendOversikthendelse(
+        motebehovUUID: UUID,
+        kOversikthendelse: KOversikthendelse
+    ) {
         try {
             kafkaTemplate.send(
                 OVERSIKTHENDELSE_TOPIC,
-                UUID.randomUUID().toString(),
+                motebehovUUID.toString(),
                 kOversikthendelse
             ).get()
             log.info("Legger oversikthendelse med id {} på kø for enhet {}", kOversikthendelse.hendelseId, kOversikthendelse.enhetId)

--- a/src/main/kotlin/no/nav/syfo/oversikthendelse/OversikthendelseService.kt
+++ b/src/main/kotlin/no/nav/syfo/oversikthendelse/OversikthendelseService.kt
@@ -3,23 +3,37 @@ package no.nav.syfo.oversikthendelse
 import no.nav.syfo.consumer.aktorregister.domain.Fodselsnummer
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
+import java.util.*
 import javax.inject.Inject
 
 @Service
 class OversikthendelseService @Inject constructor(
     private val oversikthendelseProducer: OversikthendelseProducer
 ) {
-    fun sendOversikthendelseMottatt(arbeidstakerFnr: Fodselsnummer, tildeltEnhet: String) {
-        sendOversikthendelse(arbeidstakerFnr, tildeltEnhet, OversikthendelseType.MOTEBEHOV_SVAR_MOTTATT)
+    fun sendOversikthendelseMottatt(
+        motebehovUUID: UUID,
+        arbeidstakerFnr: Fodselsnummer,
+        tildeltEnhet: String
+    ) {
+        sendOversikthendelse(motebehovUUID, arbeidstakerFnr, tildeltEnhet, OversikthendelseType.MOTEBEHOV_SVAR_MOTTATT)
     }
 
-    fun sendOversikthendelseBehandlet(arbeidstakerFnr: Fodselsnummer, tildeltEnhet: String) {
-        sendOversikthendelse(arbeidstakerFnr, tildeltEnhet, OversikthendelseType.MOTEBEHOV_SVAR_BEHANDLET)
+    fun sendOversikthendelseBehandlet(
+        motebehovUUID: UUID,
+        arbeidstakerFnr: Fodselsnummer,
+        tildeltEnhet: String
+    ) {
+        sendOversikthendelse(motebehovUUID, arbeidstakerFnr, tildeltEnhet, OversikthendelseType.MOTEBEHOV_SVAR_BEHANDLET)
     }
 
-    private fun sendOversikthendelse(fnr: Fodselsnummer, tildeltEnhet: String, oversikthendelseType: OversikthendelseType) {
+    private fun sendOversikthendelse(
+        motebehovUUID: UUID,
+        fnr: Fodselsnummer,
+        tildeltEnhet: String,
+        oversikthendelseType: OversikthendelseType
+    ) {
         val kOversikthendelse = map2KOversikthendelse(fnr, tildeltEnhet, oversikthendelseType)
-        oversikthendelseProducer.sendOversikthendelse(kOversikthendelse)
+        oversikthendelseProducer.sendOversikthendelse(motebehovUUID, kOversikthendelse)
     }
 
     private fun map2KOversikthendelse(

--- a/src/test/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidsgiverV2Test.kt
+++ b/src/test/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidsgiverV2Test.kt
@@ -430,9 +430,9 @@ class MotebehovArbeidsgiverV2Test {
             motebehovSvar = motebehovSvar
         ))
         if (motebehovSvar.harMotebehov) {
-            Mockito.verify(oversikthendelseProducer).sendOversikthendelse(any())
+            Mockito.verify(oversikthendelseProducer).sendOversikthendelse(any(), any())
         } else {
-            Mockito.verify(oversikthendelseProducer, Mockito.never()).sendOversikthendelse(any())
+            Mockito.verify(oversikthendelseProducer, Mockito.never()).sendOversikthendelse(any(), any())
         }
     }
 
@@ -465,9 +465,9 @@ class MotebehovArbeidsgiverV2Test {
         Assertions.assertThat(motebehov.skjemaType).isEqualTo(motebehovStatus.skjemaType)
         Assertions.assertThat(motebehov.motebehovSvar).isEqualToComparingFieldByField(motebehovSvar)
         if (harBehov) {
-            Mockito.verify(oversikthendelseProducer).sendOversikthendelse(any())
+            Mockito.verify(oversikthendelseProducer).sendOversikthendelse(any(), any())
         } else {
-            Mockito.verify(oversikthendelseProducer, Mockito.never()).sendOversikthendelse(any())
+            Mockito.verify(oversikthendelseProducer, Mockito.never()).sendOversikthendelse(any(), any())
         }
     }
 

--- a/src/test/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidstakerV2Test.kt
+++ b/src/test/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidstakerV2Test.kt
@@ -426,7 +426,7 @@ class MotebehovArbeidstakerV2Test {
         val motebehovList = motebehovDAO.hentMotebehovListeForOgOpprettetAvArbeidstaker(ARBEIDSTAKER_AKTORID)
 
         assertEquals(2, motebehovList.size)
-        Mockito.verify(oversikthendelseProducer, times(2)).sendOversikthendelse(any())
+        Mockito.verify(oversikthendelseProducer, times(2)).sendOversikthendelse(any(), any())
     }
 
     private fun submitMotebehovAndSendOversikthendelse(motebehovSvar: MotebehovSvar) {
@@ -434,9 +434,9 @@ class MotebehovArbeidstakerV2Test {
 
         motebehovArbeidstakerController.submitMotebehovArbeidstaker(motebehovSvar)
         if (motebehovSvar.harMotebehov) {
-            Mockito.verify(oversikthendelseProducer).sendOversikthendelse(any())
+            Mockito.verify(oversikthendelseProducer).sendOversikthendelse(any(), any())
         } else {
-            Mockito.verify(oversikthendelseProducer, Mockito.never()).sendOversikthendelse(any())
+            Mockito.verify(oversikthendelseProducer, Mockito.never()).sendOversikthendelse(any(), any())
         }
     }
 
@@ -466,9 +466,9 @@ class MotebehovArbeidstakerV2Test {
         Assertions.assertThat(motebehov.skjemaType).isEqualTo(motebehovStatus.skjemaType)
         Assertions.assertThat(motebehov.motebehovSvar).isEqualToComparingFieldByField(motebehovSvar)
         if (harBehov) {
-            Mockito.verify(oversikthendelseProducer).sendOversikthendelse(any())
+            Mockito.verify(oversikthendelseProducer).sendOversikthendelse(any(), any())
         } else {
-            Mockito.verify(oversikthendelseProducer, Mockito.never()).sendOversikthendelse(any())
+            Mockito.verify(oversikthendelseProducer, Mockito.never()).sendOversikthendelse(any(), any())
         }
     }
 

--- a/src/test/kotlin/no/nav/syfo/motebehov/api/MotebehovComponentTest.kt
+++ b/src/test/kotlin/no/nav/syfo/motebehov/api/MotebehovComponentTest.kt
@@ -138,9 +138,9 @@ class MotebehovComponentTest {
         Assertions.assertThat(motebehov.virksomhetsnummer).isEqualTo(VIRKSOMHETSNUMMER)
         Assertions.assertThat(motebehov.motebehovSvar).isEqualToComparingFieldByField(motebehovSvar)
         if (harBehov) {
-            Mockito.verify(oversikthendelseProducer).sendOversikthendelse(any())
+            Mockito.verify(oversikthendelseProducer).sendOversikthendelse(any(), any())
         } else {
-            Mockito.verify(oversikthendelseProducer, Mockito.never()).sendOversikthendelse(any())
+            Mockito.verify(oversikthendelseProducer, Mockito.never()).sendOversikthendelse(any(), any())
         }
     }
 

--- a/src/test/kotlin/no/nav/syfo/motebehov/api/MotebehovVeilederADControllerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/motebehov/api/MotebehovVeilederADControllerTest.kt
@@ -306,7 +306,10 @@ class MotebehovVeilederADControllerTest {
     }
 
     private fun behandleMotebehov(aktoerId: String, veileder: String) {
-        motebehovDAO.oppdaterUbehandledeMotebehovTilBehandlet(aktoerId, veileder)
+        val ubehandledeMotebehov = motebehovDAO.hentUbehandledeMotebehov(aktoerId)
+        ubehandledeMotebehov.forEach {
+            motebehovDAO.oppdaterUbehandledeMotebehovTilBehandlet(it.uuid, veileder)
+        }
     }
 
     private fun mockSvarFraSyfoTilgangskontroll(fnr: String, status: HttpStatus) {

--- a/src/test/kotlin/no/nav/syfo/oversikthendelse/OversikthendelseProducerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oversikthendelse/OversikthendelseProducerTest.kt
@@ -10,6 +10,7 @@ import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.kafka.support.SendResult
 import org.springframework.util.concurrent.ListenableFuture
 import java.time.LocalDateTime
+import java.util.*
 
 @ExtendWith(MockitoExtension::class)
 class OversikthendelseProducerTest {
@@ -28,7 +29,7 @@ class OversikthendelseProducerTest {
             enhetId = NAV_ENHET,
             tidspunkt = LocalDateTime.now()
         )
-        oversikthendelseProducer.sendOversikthendelse(kOversikthendelse)
+        oversikthendelseProducer.sendOversikthendelse(UUID.randomUUID(), kOversikthendelse)
         Mockito.verify(kafkaTemplate).send(ArgumentMatchers.eq(OversikthendelseProducer.OVERSIKTHENDELSE_TOPIC), ArgumentMatchers.anyString(), ArgumentMatchers.same(kOversikthendelse))
     }
 
@@ -41,7 +42,7 @@ class OversikthendelseProducerTest {
             enhetId = NAV_ENHET,
             tidspunkt = LocalDateTime.now()
         )
-        oversikthendelseProducer.sendOversikthendelse(kOversikthendelse)
+        oversikthendelseProducer.sendOversikthendelse(UUID.randomUUID(), kOversikthendelse)
         Mockito.verify(kafkaTemplate).send(ArgumentMatchers.eq(OversikthendelseProducer.OVERSIKTHENDELSE_TOPIC), ArgumentMatchers.anyString(), ArgumentMatchers.same(kOversikthendelse))
     }
 }


### PR DESCRIPTION
Use motebehovUUID as key for produced messages to both topic for Oversikthendelse. This will ensure that messages with the same key will be sent to the same partition and hence it can be guaranteed that messages with the same key is processed in order.