### PR TITLE
Fix consumption of KOversikthendelsetilfelle

### DIFF
--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KOversikthendelsetilfelle.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KOversikthendelsetilfelle.kt
@@ -14,3 +14,9 @@ data class KOversikthendelsetilfelle(
     val tom: LocalDate,
     val tidspunkt: LocalDateTime
 )
+
+fun KOversikthendelsetilfelle.previouslyProcessed(
+    lastUpdatedAt: LocalDateTime?
+) = lastUpdatedAt?.let { it ->
+    this.tidspunkt.isAfter(it)
+} ?: false


### PR DESCRIPTION
Only update existing Oppfolgingstilfelle in database with data from KOversikthendelsetilfelle if KOversikthendelsetilfelle has not already been processed. KOversikthendelsetilfelle is already processed if Tidspunkt of KOversikthendelsetilfelle is after the last update of a Oppfolgingstilfelle-row for the combination of PersonIdent/Virskomhetsnummer found in KOversikthendelsetilfelle.