### PR TITLE
Display motebehov for both AG and SM if own leader

### DIFF
--- a/src/main/kotlin/no/nav/syfo/motebehov/MotebehovOpfolgingstilfelleService.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/MotebehovOpfolgingstilfelleService.kt
@@ -20,11 +20,12 @@ class MotebehovOpfolgingstilfelleService @Inject constructor(
     fun createMotehovForArbeidgiver(
         innloggetFnr: Fodselsnummer,
         arbeidstakerFnr: Fodselsnummer,
+        isOwnLeader: Boolean,
         nyttMotebehov: NyttMotebehovArbeidsgiver
     ) {
         val activeOppfolgingstilfelle = oppfolgingstilfelleService.getActiveOppfolgingstilfelleForArbeidsgiver(arbeidstakerFnr, nyttMotebehov.virksomhetsnummer)
         if (activeOppfolgingstilfelle != null) {
-            val motebehovStatus = motebehovStatusService.motebehovStatusForArbeidsgiver(arbeidstakerFnr, nyttMotebehov.virksomhetsnummer)
+            val motebehovStatus = motebehovStatusService.motebehovStatusForArbeidsgiver(arbeidstakerFnr, isOwnLeader, nyttMotebehov.virksomhetsnummer)
 
             val isActiveOppfolgingstilfelleAvailableForAnswer = motebehovStatus.visMotebehov &&
                 motebehovStatus.skjemaType != null &&

--- a/src/main/kotlin/no/nav/syfo/motebehov/MotebehovOppfolgingstilfelleService.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/MotebehovOppfolgingstilfelleService.kt
@@ -11,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional
 import javax.inject.Inject
 
 @Service
-class MotebehovOpfolgingstilfelleService @Inject constructor(
+class MotebehovOppfolgingstilfelleService @Inject constructor(
     private val metric: Metric,
     private val motebehovService: MotebehovService,
     private val motebehovStatusService: MotebehovStatusService,
@@ -110,7 +110,7 @@ class MotebehovOpfolgingstilfelleService @Inject constructor(
     }
 
     companion object {
-        private val LOG = LoggerFactory.getLogger(MotebehovOpfolgingstilfelleService::class.java)
+        private val LOG = LoggerFactory.getLogger(MotebehovOppfolgingstilfelleService::class.java)
         private const val METRIC_CREATE_FAILED_BASE = "create_motebehov_fail_no_oppfolgingstilfelle"
         private const val METRIC_CREATE_FAILED_ARBEIDSTAKER = "${METRIC_CREATE_FAILED_BASE}_arbeidstaker"
         private const val METRIC_CREATE_FAILED_ARBEIDSGIVER = "${METRIC_CREATE_FAILED_BASE}_arbeidsgiver"

--- a/src/main/kotlin/no/nav/syfo/motebehov/MotebehovService.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/MotebehovService.kt
@@ -60,9 +60,9 @@ class MotebehovService @Inject constructor(
             .collect(Collectors.toList())
     }
 
-    fun hentMotebehovListeForArbeidstakerOpprettetAvLeder(arbeidstakerFnr: Fodselsnummer, virksomhetsnummer: String): List<Motebehov> {
+    fun hentMotebehovListeForArbeidstakerOpprettetAvLeder(arbeidstakerFnr: Fodselsnummer, isOwnLeader: Boolean, virksomhetsnummer: String): List<Motebehov> {
         val arbeidstakerAktoerId = aktorregisterConsumer.getAktorIdForFodselsnummer(Fodselsnummer(arbeidstakerFnr.value))
-        return motebehovDAO.hentMotebehovListeForArbeidstakerOpprettetAvLeder(arbeidstakerAktoerId, virksomhetsnummer)
+        return motebehovDAO.hentMotebehovListeForArbeidstakerOpprettetAvLeder(arbeidstakerAktoerId, isOwnLeader, virksomhetsnummer)
             .stream()
             .map { dbMotebehov: PMotebehov -> mapPMotebehovToMotebehov(arbeidstakerFnr, dbMotebehov) }
             .collect(Collectors.toList())

--- a/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidsgiverV2Controller.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidsgiverV2Controller.kt
@@ -44,7 +44,10 @@ class MotebehovArbeidsgiverV2Controller @Inject constructor(
         val fnr = Fodselsnummer(arbeidstakerFnr)
         brukertilgangService.kastExceptionHvisIkkeTilgang(fnr.value)
 
-        return motebehovStatusService.motebehovStatusForArbeidsgiver(fnr, virksomhetsnummer)
+        val arbeidsgiverFnr = OIDCUtil.fnrFraOIDCEkstern(contextHolder)
+        val isOwnLeader = arbeidsgiverFnr.value == fnr.value
+
+        return motebehovStatusService.motebehovStatusForArbeidsgiver(fnr, isOwnLeader, virksomhetsnummer)
     }
 
     @PostMapping(
@@ -59,9 +62,13 @@ class MotebehovArbeidsgiverV2Controller @Inject constructor(
         val arbeidstakerFnr = Fodselsnummer(nyttMotebehov.arbeidstakerFnr)
         brukertilgangService.kastExceptionHvisIkkeTilgang(arbeidstakerFnr.value)
 
+        val arbeidsgiverFnr = OIDCUtil.fnrFraOIDCEkstern(contextHolder)
+        val isOwnLeader = arbeidsgiverFnr.value == arbeidstakerFnr.value
+
         motebehovOpfolgingstilfelleService.createMotehovForArbeidgiver(
             OIDCUtil.fnrFraOIDCEkstern(contextHolder),
             arbeidstakerFnr,
+            isOwnLeader,
             nyttMotebehov
         )
     }

--- a/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidsgiverV2Controller.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidsgiverV2Controller.kt
@@ -10,7 +10,7 @@ import no.nav.syfo.api.auth.OIDCUtil
 import no.nav.syfo.consumer.aktorregister.domain.Fodselsnummer
 import no.nav.syfo.consumer.brukertilgang.BrukertilgangService
 import no.nav.syfo.metric.Metric
-import no.nav.syfo.motebehov.MotebehovOpfolgingstilfelleService
+import no.nav.syfo.motebehov.MotebehovOppfolgingstilfelleService
 import no.nav.syfo.motebehov.NyttMotebehovArbeidsgiver
 import no.nav.syfo.motebehov.motebehovstatus.MotebehovStatus
 import no.nav.syfo.motebehov.motebehovstatus.MotebehovStatusService
@@ -28,7 +28,7 @@ import org.springframework.web.bind.annotation.RestController
 class MotebehovArbeidsgiverV2Controller @Inject constructor(
     private val contextHolder: TokenValidationContextHolder,
     private val metric: Metric,
-    private val motebehovOpfolgingstilfelleService: MotebehovOpfolgingstilfelleService,
+    private val motebehovOppfolgingstilfelleService: MotebehovOppfolgingstilfelleService,
     private val motebehovStatusService: MotebehovStatusService,
     private val brukertilgangService: BrukertilgangService
 ) {
@@ -65,7 +65,7 @@ class MotebehovArbeidsgiverV2Controller @Inject constructor(
         val arbeidsgiverFnr = OIDCUtil.fnrFraOIDCEkstern(contextHolder)
         val isOwnLeader = arbeidsgiverFnr.value == arbeidstakerFnr.value
 
-        motebehovOpfolgingstilfelleService.createMotehovForArbeidgiver(
+        motebehovOppfolgingstilfelleService.createMotehovForArbeidgiver(
             OIDCUtil.fnrFraOIDCEkstern(contextHolder),
             arbeidstakerFnr,
             isOwnLeader,

--- a/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidsgiverV3Controller.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidsgiverV3Controller.kt
@@ -1,8 +1,5 @@
 package no.nav.syfo.motebehov.api
 
-import javax.inject.Inject
-import javax.validation.Valid
-import javax.validation.constraints.Pattern
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.security.token.support.core.context.TokenValidationContextHolder
 import no.nav.syfo.api.auth.tokenX.TokenXUtil
@@ -16,12 +13,10 @@ import no.nav.syfo.motebehov.motebehovstatus.MotebehovStatus
 import no.nav.syfo.motebehov.motebehovstatus.MotebehovStatusService
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.MediaType
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
+import javax.inject.Inject
+import javax.validation.Valid
+import javax.validation.constraints.Pattern
 
 @RestController
 @ProtectedWithClaims(issuer = TokenXUtil.TokenXIssuer.TOKENX, claimMap = ["acr=Level4"])
@@ -50,7 +45,10 @@ class MotebehovArbeidsgiverV3Controller @Inject constructor(
         val ansattFnr = Fodselsnummer(arbeidstakerFnr)
         brukertilgangService.kastExceptionHvisIkkeTilgangTilAnsattTokenX(ansattFnr.value)
 
-        return motebehovStatusService.motebehovStatusForArbeidsgiver(ansattFnr, virksomhetsnummer)
+        val arbeidsgiverFnr = fnrFromIdportenTokenX(contextHolder)
+        val isOwnLeader = arbeidsgiverFnr.value == ansattFnr.value
+
+        return motebehovStatusService.motebehovStatusForArbeidsgiver(ansattFnr, isOwnLeader, virksomhetsnummer)
     }
 
     @PostMapping(
@@ -67,9 +65,13 @@ class MotebehovArbeidsgiverV3Controller @Inject constructor(
         val ansattFnr = Fodselsnummer(nyttMotebehov.arbeidstakerFnr)
         brukertilgangService.kastExceptionHvisIkkeTilgangTilAnsattTokenX(ansattFnr.value)
 
+        val arbeidsgiverFnr = fnrFromIdportenTokenX(contextHolder)
+        val isOwnLeader = arbeidsgiverFnr.value == ansattFnr.value
+
         motebehovOpfolgingstilfelleService.createMotehovForArbeidgiver(
             innloggetFnr,
             ansattFnr,
+            isOwnLeader,
             nyttMotebehov
         )
     }

--- a/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidsgiverV3Controller.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidsgiverV3Controller.kt
@@ -7,7 +7,7 @@ import no.nav.syfo.api.auth.tokenX.TokenXUtil.fnrFromIdportenTokenX
 import no.nav.syfo.consumer.aktorregister.domain.Fodselsnummer
 import no.nav.syfo.consumer.brukertilgang.BrukertilgangService
 import no.nav.syfo.metric.Metric
-import no.nav.syfo.motebehov.MotebehovOpfolgingstilfelleService
+import no.nav.syfo.motebehov.MotebehovOppfolgingstilfelleService
 import no.nav.syfo.motebehov.NyttMotebehovArbeidsgiver
 import no.nav.syfo.motebehov.motebehovstatus.MotebehovStatus
 import no.nav.syfo.motebehov.motebehovstatus.MotebehovStatusService
@@ -24,7 +24,7 @@ import javax.validation.constraints.Pattern
 class MotebehovArbeidsgiverV3Controller @Inject constructor(
     private val contextHolder: TokenValidationContextHolder,
     private val metric: Metric,
-    private val motebehovOpfolgingstilfelleService: MotebehovOpfolgingstilfelleService,
+    private val motebehovOppfolgingstilfelleService: MotebehovOppfolgingstilfelleService,
     private val motebehovStatusService: MotebehovStatusService,
     private val brukertilgangService: BrukertilgangService,
     @Value("\${dialogmote.frontend.client.id}")
@@ -68,7 +68,7 @@ class MotebehovArbeidsgiverV3Controller @Inject constructor(
         val arbeidsgiverFnr = fnrFromIdportenTokenX(contextHolder)
         val isOwnLeader = arbeidsgiverFnr.value == ansattFnr.value
 
-        motebehovOpfolgingstilfelleService.createMotehovForArbeidgiver(
+        motebehovOppfolgingstilfelleService.createMotehovForArbeidgiver(
             innloggetFnr,
             ansattFnr,
             isOwnLeader,

--- a/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidstakerV2Controller.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidstakerV2Controller.kt
@@ -8,7 +8,7 @@ import no.nav.syfo.api.auth.OIDCIssuer
 import no.nav.syfo.api.auth.OIDCUtil
 import no.nav.syfo.consumer.brukertilgang.BrukertilgangService
 import no.nav.syfo.metric.Metric
-import no.nav.syfo.motebehov.MotebehovOpfolgingstilfelleService
+import no.nav.syfo.motebehov.MotebehovOppfolgingstilfelleService
 import no.nav.syfo.motebehov.MotebehovSvar
 import no.nav.syfo.motebehov.motebehovstatus.MotebehovStatus
 import no.nav.syfo.motebehov.motebehovstatus.MotebehovStatusService
@@ -26,7 +26,7 @@ class MotebehovArbeidstakerV2Controller @Inject constructor(
     private val contextHolder: TokenValidationContextHolder,
     private val metric: Metric,
     private val motebehovStatusService: MotebehovStatusService,
-    private val motebehovOpfolgingstilfelleService: MotebehovOpfolgingstilfelleService,
+    private val motebehovOppfolgingstilfelleService: MotebehovOppfolgingstilfelleService,
     private val brukertilgangService: BrukertilgangService
 ) {
     @GetMapping(
@@ -54,7 +54,7 @@ class MotebehovArbeidstakerV2Controller @Inject constructor(
         val arbeidstakerFnr = OIDCUtil.fnrFraOIDCEkstern(contextHolder)
         brukertilgangService.kastExceptionHvisIkkeTilgang(arbeidstakerFnr.value)
 
-        motebehovOpfolgingstilfelleService.createMotehovForArbeidstaker(
+        motebehovOppfolgingstilfelleService.createMotehovForArbeidstaker(
             OIDCUtil.fnrFraOIDCEkstern(contextHolder),
             nyttMotebehovSvar
         )

--- a/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidstakerV3Controller.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidstakerV3Controller.kt
@@ -9,7 +9,7 @@ import no.nav.syfo.api.auth.tokenX.TokenXUtil.TokenXIssuer
 import no.nav.syfo.api.auth.tokenX.TokenXUtil.fnrFromIdportenTokenX
 import no.nav.syfo.consumer.brukertilgang.BrukertilgangService
 import no.nav.syfo.metric.Metric
-import no.nav.syfo.motebehov.MotebehovOpfolgingstilfelleService
+import no.nav.syfo.motebehov.MotebehovOppfolgingstilfelleService
 import no.nav.syfo.motebehov.MotebehovSvar
 import no.nav.syfo.motebehov.motebehovstatus.MotebehovStatus
 import no.nav.syfo.motebehov.motebehovstatus.MotebehovStatusService
@@ -28,7 +28,7 @@ class MotebehovArbeidstakerV3Controller @Inject constructor(
     private val contextHolder: TokenValidationContextHolder,
     private val metric: Metric,
     private val motebehovStatusService: MotebehovStatusService,
-    private val motebehovOpfolgingstilfelleService: MotebehovOpfolgingstilfelleService,
+    private val motebehovOppfolgingstilfelleService: MotebehovOppfolgingstilfelleService,
     private val brukertilgangService: BrukertilgangService,
     @Value("\${dialogmote.frontend.client.id}")
     val dialogmoteClientId: String,
@@ -63,7 +63,7 @@ class MotebehovArbeidstakerV3Controller @Inject constructor(
 
         brukertilgangService.kastExceptionHvisIkkeTilgangTilSegSelv(arbeidstakerFnr.value)
 
-        motebehovOpfolgingstilfelleService.createMotehovForArbeidstaker(
+        motebehovOppfolgingstilfelleService.createMotehovForArbeidstaker(
             arbeidstakerFnr,
             nyttMotebehovSvar
         )

--- a/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovBrukerController.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovBrukerController.kt
@@ -38,8 +38,12 @@ class MotebehovBrukerController @Inject constructor(
                 arbeidstakerFnr!!
             )
         brukertilgangService.kastExceptionHvisIkkeTilgang(fnr.value)
+
+        val arbeidsgiverFnr = OIDCUtil.fnrFraOIDCEkstern(contextHolder)
+        val isOwnLeader = arbeidsgiverFnr.value == fnr.value
+
         return if (virksomhetsnummer.isNotEmpty()) {
-            motebehovService.hentMotebehovListeForArbeidstakerOpprettetAvLeder(fnr, virksomhetsnummer)
+            motebehovService.hentMotebehovListeForArbeidstakerOpprettetAvLeder(fnr, isOwnLeader, virksomhetsnummer)
         } else motebehovService.hentMotebehovListeForOgOpprettetAvArbeidstaker(fnr)
     }
 

--- a/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovBrukerController.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovBrukerController.kt
@@ -39,11 +39,8 @@ class MotebehovBrukerController @Inject constructor(
             )
         brukertilgangService.kastExceptionHvisIkkeTilgang(fnr.value)
 
-        val arbeidsgiverFnr = OIDCUtil.fnrFraOIDCEkstern(contextHolder)
-        val isOwnLeader = arbeidsgiverFnr.value == fnr.value
-
         return if (virksomhetsnummer.isNotEmpty()) {
-            motebehovService.hentMotebehovListeForArbeidstakerOpprettetAvLeder(fnr, isOwnLeader, virksomhetsnummer)
+            motebehovService.hentMotebehovListeForArbeidstakerOpprettetAvLeder(fnr, false, virksomhetsnummer)
         } else motebehovService.hentMotebehovListeForOgOpprettetAvArbeidstaker(fnr)
     }
 

--- a/src/main/kotlin/no/nav/syfo/motebehov/database/MotebehovDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/database/MotebehovDAO.kt
@@ -31,7 +31,11 @@ class MotebehovDAO(private val namedParameterJdbcTemplate: NamedParameterJdbcTem
         return Optional.ofNullable(jdbcTemplate.query("SELECT * FROM motebehov WHERE aktoer_id = ? AND opprettet_av = ? AND opprettet_dato >= ? ORDER BY opprettet_dato DESC", innsendingRowMapper, arbeidstakerAktorId, arbeidstakerAktorId, hentTidligsteDatoForGyldigMotebehovSvar())).orElse(emptyList())
     }
 
-    fun hentMotebehovListeForArbeidstakerOpprettetAvLeder(arbeidstakerAktorId: String, virksomhetsnummer: String): List<PMotebehov> {
+    fun hentMotebehovListeForArbeidstakerOpprettetAvLeder(arbeidstakerAktorId: String, isOwnLeader: Boolean, virksomhetsnummer: String): List<PMotebehov> {
+        if (isOwnLeader) {
+            return Optional.ofNullable(jdbcTemplate.query("SELECT * FROM motebehov WHERE aktoer_id = ? AND virksomhetsnummer = ? AND opprettet_dato >= ? ORDER BY opprettet_dato DESC", innsendingRowMapper, arbeidstakerAktorId, virksomhetsnummer, hentTidligsteDatoForGyldigMotebehovSvar())).orElse(emptyList())
+        }
+
         return Optional.ofNullable(jdbcTemplate.query("SELECT * FROM motebehov WHERE aktoer_id = ? AND opprettet_av != ? AND virksomhetsnummer = ? AND opprettet_dato >= ? ORDER BY opprettet_dato DESC", innsendingRowMapper, arbeidstakerAktorId, arbeidstakerAktorId, virksomhetsnummer, hentTidligsteDatoForGyldigMotebehovSvar())).orElse(emptyList())
     }
 

--- a/src/main/kotlin/no/nav/syfo/motebehov/motebehovstatus/MotebehovStatusService.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/motebehovstatus/MotebehovStatusService.kt
@@ -34,12 +34,13 @@ class MotebehovStatusService @Inject constructor(
     }
     fun motebehovStatusForArbeidsgiver(
         arbeidstakerFnr: Fodselsnummer,
+        isOwnLeader: Boolean,
         virksomhetsnummer: String
     ): MotebehovStatus {
         val oppfolgingstilfelle =
             oppfolgingstilfelleService.getActiveOppfolgingstilfelleForArbeidsgiver(arbeidstakerFnr, virksomhetsnummer)
         val motebehovList =
-            motebehovService.hentMotebehovListeForArbeidstakerOpprettetAvLeder(arbeidstakerFnr, virksomhetsnummer)
+            motebehovService.hentMotebehovListeForArbeidstakerOpprettetAvLeder(arbeidstakerFnr, isOwnLeader, virksomhetsnummer)
 
         return motebehovStatus(oppfolgingstilfelle, motebehovList)
     }

--- a/src/main/kotlin/no/nav/syfo/varsel/VarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/varsel/VarselService.kt
@@ -93,7 +93,7 @@ class VarselService @Inject constructor(
         virksomhetsnummer: String
     ): Boolean {
         return isSvarBehovVarselAvailable(
-            motebehovService.hentMotebehovListeForArbeidstakerOpprettetAvLeder(arbeidstakerFnr, virksomhetsnummer),
+            motebehovService.hentMotebehovListeForArbeidstakerOpprettetAvLeder(arbeidstakerFnr, false, virksomhetsnummer),
             oppfolgingstilfelleService.getActiveOppfolgingstilfelleForArbeidsgiver(arbeidstakerFnr, virksomhetsnummer)
         )
     }

--- a/src/test/kotlin/no/nav/syfo/motebehov/database/MotebehovDAOTest.kt
+++ b/src/test/kotlin/no/nav/syfo/motebehov/database/MotebehovDAOTest.kt
@@ -93,7 +93,7 @@ class MotebehovDAOTest {
             opprettetAv = LEDER_AKTORID
         )
         insertPMotebehov(pMotebehov)
-        val motebehovListe = motebehovDAO.hentMotebehovListeForArbeidstakerOpprettetAvLeder(ARBEIDSTAKER_AKTORID, VIRKSOMHETSNUMMER)
+        val motebehovListe = motebehovDAO.hentMotebehovListeForArbeidstakerOpprettetAvLeder(ARBEIDSTAKER_AKTORID, false, VIRKSOMHETSNUMMER)
         Assertions.assertThat(motebehovListe.size).isEqualTo(0)
     }
 
@@ -105,11 +105,26 @@ class MotebehovDAOTest {
             opprettetAv = LEDER_AKTORID
         )
         insertPMotebehov(pMotebehov)
-        val motebehovListe = motebehovDAO.hentMotebehovListeForArbeidstakerOpprettetAvLeder(ARBEIDSTAKER_AKTORID, VIRKSOMHETSNUMMER)
+        val motebehovListe = motebehovDAO.hentMotebehovListeForArbeidstakerOpprettetAvLeder(ARBEIDSTAKER_AKTORID, false, VIRKSOMHETSNUMMER)
         Assertions.assertThat(motebehovListe.size).isEqualTo(1)
         val motebehovFraDb = motebehovListe[0]
         Assertions.assertThat(motebehovFraDb.opprettetDato.truncatedTo(ChronoUnit.SECONDS)).isEqualTo(pMotebehov.opprettetDato.truncatedTo(ChronoUnit.SECONDS))
         Assertions.assertThat(motebehovFraDb.opprettetAv).isEqualTo(LEDER_AKTORID)
+        Assertions.assertThat(motebehovFraDb.aktoerId).isEqualTo(pMotebehov.aktoerId)
+    }
+
+    @Test
+    fun skalHenteAlleMotebehovForAktorDersomEgenLeder() {
+        val pMotebehov = motebehovGenerator.generatePmotebehov().copy(
+            opprettetDato = motebehovGenerator.getOpprettetDato(true),
+            opprettetAv = ARBEIDSTAKER_AKTORID
+        )
+        insertPMotebehov(pMotebehov)
+        val motebehovListe = motebehovDAO.hentMotebehovListeForArbeidstakerOpprettetAvLeder(ARBEIDSTAKER_AKTORID, true, VIRKSOMHETSNUMMER)
+        Assertions.assertThat(motebehovListe.size).isEqualTo(1)
+        val motebehovFraDb = motebehovListe[0]
+        Assertions.assertThat(motebehovFraDb.opprettetDato.truncatedTo(ChronoUnit.SECONDS)).isEqualTo(pMotebehov.opprettetDato.truncatedTo(ChronoUnit.SECONDS))
+        Assertions.assertThat(motebehovFraDb.opprettetAv).isEqualTo(ARBEIDSTAKER_AKTORID)
         Assertions.assertThat(motebehovFraDb.aktoerId).isEqualTo(pMotebehov.aktoerId)
     }
 

--- a/src/test/kotlin/no/nav/syfo/varsel/VarselLederComponentTest.kt
+++ b/src/test/kotlin/no/nav/syfo/varsel/VarselLederComponentTest.kt
@@ -193,6 +193,7 @@ class VarselLederComponentTest {
         `when`(
             motebehovService.hentMotebehovListeForArbeidstakerOpprettetAvLeder(
                 Fodselsnummer(ARBEIDSTAKER_FNR),
+                false,
                 VIRKSOMHETSNUMMER
             )
         )
@@ -236,6 +237,7 @@ class VarselLederComponentTest {
         `when`(
             motebehovService.hentMotebehovListeForArbeidstakerOpprettetAvLeder(
                 Fodselsnummer(ARBEIDSTAKER_FNR),
+                false,
                 VIRKSOMHETSNUMMER
             )
         )


### PR DESCRIPTION
Dersom noen som er sin egen leder melder inn møtebehov, så er det nå ønskelig å vise frem svaret både på SM og AG-siden.