### PR TITLE
Use kandidatliste for status

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,8 @@ object Versions {
     const val tokenSupportVersion = "1.3.19"
     const val ojdbcVersion = "19.3.0.0"
     const val h2Version = "2.1.210"
+    const val mockkVersion = "1.12.7"
+    const val springMockkVersion = "3.1.1"
     const val confluent = "7.1.1"
     const val isdialogmoteSchema = "1.0.5"
 }
@@ -93,6 +95,8 @@ dependencies {
         exclude(module = "junit")
     }
     testImplementation("com.h2database:h2:${Versions.h2Version}")
+    testImplementation("io.mockk:mockk:${Versions.mockkVersion}")
+    testImplementation("com.ninja-squad:springmockk:${Versions.springMockkVersion}")
 }
 
 tasks {

--- a/naiserator-dev.yaml
+++ b/naiserator-dev.yaml
@@ -120,3 +120,5 @@ spec:
       value: https://oidc-ver2.difi.no/idporten-oidc-provider/
     - name: DITT_SYKEFRAVAER_FRONTEND_CLIENT_ID
       value: dev-gcp:flex:ditt-sykefravaer
+    - name: USE_KANDIDATLISTA
+      value: "true"

--- a/naiserator-dev.yaml
+++ b/naiserator-dev.yaml
@@ -120,5 +120,5 @@ spec:
       value: https://oidc-ver2.difi.no/idporten-oidc-provider/
     - name: DITT_SYKEFRAVAER_FRONTEND_CLIENT_ID
       value: dev-gcp:flex:ditt-sykefravaer
-    - name: USE_KANDIDATLISTA
+    - name: TOGGLE_KANDIDATLISTA
       value: "true"

--- a/naiserator-prod.yaml
+++ b/naiserator-prod.yaml
@@ -118,3 +118,5 @@ spec:
     - name: DITT_SYKEFRAVAER_FRONTEND_CLIENT_ID
       value: prod-gcp:flex:ditt-sykefravaer
 
+    - name: USE_KANDIDATLISTA
+      value: "false"

--- a/naiserator-prod.yaml
+++ b/naiserator-prod.yaml
@@ -117,6 +117,5 @@ spec:
       value: https://oidc.difi.no/idporten-oidc-provider/
     - name: DITT_SYKEFRAVAER_FRONTEND_CLIENT_ID
       value: prod-gcp:flex:ditt-sykefravaer
-
-    - name: USE_KANDIDATLISTA
+    - name: TOGGLE_KANDIDATLISTA
       value: "false"

--- a/src/main/kotlin/no/nav/syfo/dialogmotekandidat/DialogmotekandidatService.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmotekandidat/DialogmotekandidatService.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.dialogmotekandidat
 
 import no.nav.syfo.consumer.aktorregister.domain.Fodselsnummer
+import no.nav.syfo.dialogmotekandidat.database.DialogmoteKandidatEndring
 import no.nav.syfo.dialogmotekandidat.database.DialogmotekandidatDAO
 import no.nav.syfo.dialogmotekandidat.kafka.KafkaDialogmotekandidatEndring
 import no.nav.syfo.util.toNorwegianLocalDateTime
@@ -40,6 +41,10 @@ class DialogmotekandidatService @Inject constructor(
                 )
             }
         }
+    }
+
+    fun getDialogmotekandidatStatus(arbeidstakerFnr: Fodselsnummer): DialogmoteKandidatEndring? {
+        return dialogmotekandidatDAO.get(arbeidstakerFnr)
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/syfo/dialogmotekandidat/database/DialogmotekandidatDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmotekandidat/database/DialogmotekandidatDAO.kt
@@ -97,6 +97,14 @@ class DialogmotekandidatDAO @Inject constructor(
         )
     }
 
+    fun delete(fnr: Fodselsnummer): Int {
+        return namedParameterJdbcTemplate.update(
+            "DELETE FROM DIALOGMOTEKANDIDAT WHERE $COLUMN_PERSON_IDENT = (:fnr)",
+            MapSqlParameterSource()
+                .addValue("fnr", fnr.value)
+        )
+    }
+
     companion object {
         const val COLUMN_UUID = "uuid"
         const val COLUMN_EXTERNAL_UUID = "dialogmotekandidat_external_uuid"

--- a/src/main/kotlin/no/nav/syfo/dialogmotekandidat/kafka/DialogmotekandidatListener.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmotekandidat/kafka/DialogmotekandidatListener.kt
@@ -19,19 +19,19 @@ class DialogmotekandidatListener(
         consumerRecord: ConsumerRecord<String, KafkaDialogmotekandidatEndring>,
         acknowledgment: Acknowledgment
     ) {
-        LOG.info("Got record from $DIALOGMOTEKANDIDAT_TOPIC topic for uuid: ${consumerRecord.value().uuid}")
+        log.info("Got record from $DIALOGMOTEKANDIDAT_TOPIC topic for uuid: ${consumerRecord.value().uuid}")
         try {
             dialogmotekandidatService.receiveDialogmotekandidatEndring(consumerRecord.value())
             acknowledgment.acknowledge()
         } catch (e: JsonProcessingException) {
-            LOG.error("DialogmotekandidatListener: Kunne ikke deserialisere topic", e)
+            log.error("DialogmotekandidatListener: Kunne ikke deserialisere topic", e)
         } catch (e: Exception) {
-            LOG.error("DialogmotekandidatListener: Uventet feil ved lesing av topic", e)
+            log.error("DialogmotekandidatListener: Uventet feil ved lesing av topic", e)
         }
     }
 
     companion object {
-        private val LOG = LoggerFactory.getLogger(DialogmotekandidatListener::class.java)
+        private val log = LoggerFactory.getLogger(DialogmotekandidatListener::class.java)
         const val DIALOGMOTEKANDIDAT_TOPIC = "teamsykefravr.isdialogmotekandidat-dialogmotekandidat"
     }
 }

--- a/src/main/kotlin/no/nav/syfo/dialogmotekandidat/kafka/KafkaDialogmotekandidatConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmotekandidat/kafka/KafkaDialogmotekandidatConfig.kt
@@ -18,7 +18,7 @@ class KafkaDialogmotekandidatConfig @Inject constructor(
     private val kafkaAivenConfig: KafkaAivenConfig
 ) {
     @Bean
-    fun dialogmoteKandidatConsumerFactory(): ConsumerFactory<String, KafkaDialogmotekandidatEndring> {
+    fun dialogmotekandidatConsumerFactory(): ConsumerFactory<String, KafkaDialogmotekandidatEndring> {
 
         fun kafkaDialogmotekandidatConsumerConfig(): HashMap<String, Any> {
             return HashMap<String, Any>().apply {
@@ -45,7 +45,7 @@ class KafkaDialogmotekandidatConfig @Inject constructor(
     fun kafkaListenerContainerFactory(): ConcurrentKafkaListenerContainerFactory<String, KafkaDialogmotekandidatEndring> {
         return ConcurrentKafkaListenerContainerFactory<String, KafkaDialogmotekandidatEndring>().apply {
             this.containerProperties.ackMode = ContainerProperties.AckMode.MANUAL_IMMEDIATE
-            this.consumerFactory = dialogmoteKandidatConsumerFactory()
+            this.consumerFactory = dialogmotekandidatConsumerFactory()
         }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/motebehov/MotebehovOppfolgingstilfelleServiceV2.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/MotebehovOppfolgingstilfelleServiceV2.kt
@@ -1,0 +1,115 @@
+package no.nav.syfo.motebehov
+
+import no.nav.syfo.api.exception.ConflictException
+import no.nav.syfo.consumer.aktorregister.domain.Fodselsnummer
+import no.nav.syfo.metric.Metric
+import no.nav.syfo.motebehov.motebehovstatus.MotebehovStatusServiceV2
+import no.nav.syfo.motebehov.motebehovstatus.isMotebehovAvailableForAnswer
+import no.nav.syfo.oppfolgingstilfelle.OppfolgingstilfelleService
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import javax.inject.Inject
+
+@Service
+class MotebehovOppfolgingstilfelleServiceV2 @Inject constructor(
+    private val metric: Metric,
+    private val motebehovService: MotebehovService,
+    private val motebehovStatusServiceV2: MotebehovStatusServiceV2,
+    private val oppfolgingstilfelleService: OppfolgingstilfelleService
+) {
+    fun createMotebehovForArbeidgiver(
+        innloggetFnr: Fodselsnummer,
+        arbeidstakerFnr: Fodselsnummer,
+        isOwnLeader: Boolean,
+        nyttMotebehov: NyttMotebehovArbeidsgiver
+    ) {
+        LOG.info("Oppretter nytt møtebehov for arbeidsgiver")
+
+        val activeOppfolgingstilfelle = oppfolgingstilfelleService.getActiveOppfolgingstilfelleForArbeidsgiver(arbeidstakerFnr, nyttMotebehov.virksomhetsnummer)
+        if (activeOppfolgingstilfelle != null) {
+            val motebehovStatus = motebehovStatusServiceV2.motebehovStatusForArbeidsgiver(arbeidstakerFnr, isOwnLeader, nyttMotebehov.virksomhetsnummer)
+
+            if (motebehovStatus.isMotebehovAvailableForAnswer()) {
+                motebehovService.lagreMotebehov(
+                    innloggetFnr,
+                    arbeidstakerFnr,
+                    nyttMotebehov.virksomhetsnummer,
+                    motebehovStatus.skjemaType!!,
+                    nyttMotebehov.motebehovSvar
+                )
+                metric.tellBesvarMotebehov(
+                    activeOppfolgingstilfelle,
+                    motebehovStatus.skjemaType,
+                    nyttMotebehov.motebehovSvar,
+                    false
+                )
+            } else {
+                metric.tellHendelse(METRIC_CREATE_FAILED_ARBEIDSGIVER)
+                throwCreateMotebehovConflict("Failed to create Motebehov for Arbeidsgiver: Found no Virksomhetsnummer with active Oppfolgingstilfelle available for answer")
+            }
+        } else {
+            metric.tellHendelse(METRIC_CREATE_FAILED_ARBEIDSGIVER)
+            throwCreateMotebehovFailed("Failed to create Motebehov for Arbeidsgiver: Found no Virksomhetsnummer with active Oppfolgingstilfelle for ${nyttMotebehov.virksomhetsnummer}")
+        }
+    }
+
+    @Transactional
+    fun createMotebehovForArbeidstaker(arbeidstakerFnr: Fodselsnummer, motebehovSvar: MotebehovSvar) {
+        LOG.info("Oppretter nytt møtebehov for arbeidstaker")
+
+        val activeOppolgingstilfelle = oppfolgingstilfelleService.getActiveOppfolgingstilfelleForArbeidstaker(arbeidstakerFnr)
+        if (activeOppolgingstilfelle != null) {
+            val motebehovStatus = motebehovStatusServiceV2.motebehovStatusForArbeidstaker(arbeidstakerFnr)
+
+            val virksomhetsnummerList = if (motebehovStatus.isMotebehovAvailableForAnswer()) {
+                oppfolgingstilfelleService.getActiveOppfolgingstilfeller(arbeidstakerFnr).map {
+                    it.virksomhetsnummer
+                }.toList()
+            } else {
+                emptyList()
+            }
+
+            if (virksomhetsnummerList.isNotEmpty()) {
+                for (virksomhetsnummer in virksomhetsnummerList) {
+                    motebehovService.lagreMotebehov(
+                        arbeidstakerFnr,
+                        arbeidstakerFnr,
+                        virksomhetsnummer,
+                        motebehovStatus.skjemaType!!,
+                        motebehovSvar
+                    )
+                }
+                metric.tellBesvarMotebehov(
+                    activeOppolgingstilfelle,
+                    motebehovStatus.skjemaType,
+                    motebehovSvar,
+                    true
+                )
+            } else {
+                metric.tellHendelse(METRIC_CREATE_FAILED_ARBEIDSTAKER)
+                throwCreateMotebehovConflict("Failed to create Motebehov for Arbeidstaker: Found no Virksomhetsnummer with active Oppfolgingstilfelle")
+            }
+        } else {
+            metric.tellHendelse(METRIC_CREATE_FAILED_ARBEIDSTAKER)
+            throwCreateMotebehovFailed("Failed to create Motebehov for Arbeidstaker: Found no Virksomhetsnummer with active Oppfolgingstilfelle")
+        }
+    }
+
+    private fun throwCreateMotebehovConflict(errorMessage: String) {
+        LOG.warn(errorMessage)
+        throw ConflictException()
+    }
+
+    private fun throwCreateMotebehovFailed(errorMessage: String) {
+        LOG.error(errorMessage)
+        throw RuntimeException(errorMessage)
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(MotebehovOppfolgingstilfelleServiceV2::class.java)
+        private const val METRIC_CREATE_FAILED_BASE = "create_motebehov_fail_no_oppfolgingstilfelle"
+        private const val METRIC_CREATE_FAILED_ARBEIDSTAKER = "${METRIC_CREATE_FAILED_BASE}_arbeidstaker"
+        private const val METRIC_CREATE_FAILED_ARBEIDSGIVER = "${METRIC_CREATE_FAILED_BASE}_arbeidsgiver"
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/motebehov/MotebehovOppfolgingstilfelleServiceV2.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/MotebehovOppfolgingstilfelleServiceV2.kt
@@ -24,8 +24,6 @@ class MotebehovOppfolgingstilfelleServiceV2 @Inject constructor(
         isOwnLeader: Boolean,
         nyttMotebehov: NyttMotebehovArbeidsgiver
     ) {
-        LOG.info("Oppretter nytt møtebehov for arbeidsgiver")
-
         val activeOppfolgingstilfelle = oppfolgingstilfelleService.getActiveOppfolgingstilfelleForArbeidsgiver(arbeidstakerFnr, nyttMotebehov.virksomhetsnummer)
         if (activeOppfolgingstilfelle != null) {
             val motebehovStatus = motebehovStatusServiceV2.motebehovStatusForArbeidsgiver(arbeidstakerFnr, isOwnLeader, nyttMotebehov.virksomhetsnummer)
@@ -56,8 +54,6 @@ class MotebehovOppfolgingstilfelleServiceV2 @Inject constructor(
 
     @Transactional
     fun createMotebehovForArbeidstaker(arbeidstakerFnr: Fodselsnummer, motebehovSvar: MotebehovSvar) {
-        LOG.info("Oppretter nytt møtebehov for arbeidstaker")
-
         val activeOppolgingstilfelle = oppfolgingstilfelleService.getActiveOppfolgingstilfelleForArbeidstaker(arbeidstakerFnr)
         if (activeOppolgingstilfelle != null) {
             val motebehovStatus = motebehovStatusServiceV2.motebehovStatusForArbeidstaker(arbeidstakerFnr)
@@ -97,17 +93,17 @@ class MotebehovOppfolgingstilfelleServiceV2 @Inject constructor(
     }
 
     private fun throwCreateMotebehovConflict(errorMessage: String) {
-        LOG.warn(errorMessage)
+        log.warn(errorMessage)
         throw ConflictException()
     }
 
     private fun throwCreateMotebehovFailed(errorMessage: String) {
-        LOG.error(errorMessage)
+        log.error(errorMessage)
         throw RuntimeException(errorMessage)
     }
 
     companion object {
-        private val LOG = LoggerFactory.getLogger(MotebehovOppfolgingstilfelleServiceV2::class.java)
+        private val log = LoggerFactory.getLogger(MotebehovOppfolgingstilfelleServiceV2::class.java)
         private const val METRIC_CREATE_FAILED_BASE = "create_motebehov_fail_no_oppfolgingstilfelle"
         private const val METRIC_CREATE_FAILED_ARBEIDSTAKER = "${METRIC_CREATE_FAILED_BASE}_arbeidstaker"
         private const val METRIC_CREATE_FAILED_ARBEIDSGIVER = "${METRIC_CREATE_FAILED_BASE}_arbeidsgiver"

--- a/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidsgiverV2Controller.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidsgiverV2Controller.kt
@@ -11,9 +11,12 @@ import no.nav.syfo.consumer.aktorregister.domain.Fodselsnummer
 import no.nav.syfo.consumer.brukertilgang.BrukertilgangService
 import no.nav.syfo.metric.Metric
 import no.nav.syfo.motebehov.MotebehovOppfolgingstilfelleService
+import no.nav.syfo.motebehov.MotebehovOppfolgingstilfelleServiceV2
 import no.nav.syfo.motebehov.NyttMotebehovArbeidsgiver
 import no.nav.syfo.motebehov.motebehovstatus.MotebehovStatus
 import no.nav.syfo.motebehov.motebehovstatus.MotebehovStatusService
+import no.nav.syfo.motebehov.motebehovstatus.MotebehovStatusServiceV2
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -29,8 +32,12 @@ class MotebehovArbeidsgiverV2Controller @Inject constructor(
     private val contextHolder: TokenValidationContextHolder,
     private val metric: Metric,
     private val motebehovOppfolgingstilfelleService: MotebehovOppfolgingstilfelleService,
+    private val motebehovOppfolgingstilfelleServiceV2: MotebehovOppfolgingstilfelleServiceV2,
     private val motebehovStatusService: MotebehovStatusService,
-    private val brukertilgangService: BrukertilgangService
+    private val motebehovStatusServiceV2: MotebehovStatusServiceV2,
+    private val brukertilgangService: BrukertilgangService,
+    @Value("\${use.kandidatlista}")
+    private val useKandidatlista: Boolean,
 ) {
     @GetMapping(
         value = ["/motebehov"],
@@ -46,6 +53,10 @@ class MotebehovArbeidsgiverV2Controller @Inject constructor(
 
         val arbeidsgiverFnr = OIDCUtil.fnrFraOIDCEkstern(contextHolder)
         val isOwnLeader = arbeidsgiverFnr.value == fnr.value
+
+        if (useKandidatlista) {
+            return motebehovStatusServiceV2.motebehovStatusForArbeidsgiver(fnr, isOwnLeader, virksomhetsnummer)
+        }
 
         return motebehovStatusService.motebehovStatusForArbeidsgiver(fnr, isOwnLeader, virksomhetsnummer)
     }
@@ -65,11 +76,20 @@ class MotebehovArbeidsgiverV2Controller @Inject constructor(
         val arbeidsgiverFnr = OIDCUtil.fnrFraOIDCEkstern(contextHolder)
         val isOwnLeader = arbeidsgiverFnr.value == arbeidstakerFnr.value
 
-        motebehovOppfolgingstilfelleService.createMotehovForArbeidgiver(
-            OIDCUtil.fnrFraOIDCEkstern(contextHolder),
-            arbeidstakerFnr,
-            isOwnLeader,
-            nyttMotebehov
-        )
+        if (useKandidatlista) {
+            motebehovOppfolgingstilfelleServiceV2.createMotebehovForArbeidgiver(
+                OIDCUtil.fnrFraOIDCEkstern(contextHolder),
+                arbeidstakerFnr,
+                isOwnLeader,
+                nyttMotebehov
+            )
+        } else {
+            motebehovOppfolgingstilfelleService.createMotehovForArbeidgiver(
+                OIDCUtil.fnrFraOIDCEkstern(contextHolder),
+                arbeidstakerFnr,
+                isOwnLeader,
+                nyttMotebehov
+            )
+        }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidsgiverV2Controller.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidsgiverV2Controller.kt
@@ -36,7 +36,7 @@ class MotebehovArbeidsgiverV2Controller @Inject constructor(
     private val motebehovStatusService: MotebehovStatusService,
     private val motebehovStatusServiceV2: MotebehovStatusServiceV2,
     private val brukertilgangService: BrukertilgangService,
-    @Value("\${use.kandidatlista}")
+    @Value("\${toggle.kandidatlista}")
     private val useKandidatlista: Boolean,
 ) {
     @GetMapping(

--- a/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidsgiverV3Controller.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidsgiverV3Controller.kt
@@ -35,7 +35,7 @@ class MotebehovArbeidsgiverV3Controller @Inject constructor(
     val dialogmoteClientId: String,
     @Value("\${tokenx.idp}")
     val dialogmoteTokenxIdp: String,
-    @Value("\${use.kandidatlista}")
+    @Value("\${toggle.kandidatlista}")
     private val useKandidatlista: Boolean,
 ) {
     @GetMapping(

--- a/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidsgiverV3Controller.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidsgiverV3Controller.kt
@@ -8,9 +8,11 @@ import no.nav.syfo.consumer.aktorregister.domain.Fodselsnummer
 import no.nav.syfo.consumer.brukertilgang.BrukertilgangService
 import no.nav.syfo.metric.Metric
 import no.nav.syfo.motebehov.MotebehovOppfolgingstilfelleService
+import no.nav.syfo.motebehov.MotebehovOppfolgingstilfelleServiceV2
 import no.nav.syfo.motebehov.NyttMotebehovArbeidsgiver
 import no.nav.syfo.motebehov.motebehovstatus.MotebehovStatus
 import no.nav.syfo.motebehov.motebehovstatus.MotebehovStatusService
+import no.nav.syfo.motebehov.motebehovstatus.MotebehovStatusServiceV2
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.*
@@ -25,12 +27,16 @@ class MotebehovArbeidsgiverV3Controller @Inject constructor(
     private val contextHolder: TokenValidationContextHolder,
     private val metric: Metric,
     private val motebehovOppfolgingstilfelleService: MotebehovOppfolgingstilfelleService,
+    private val motebehovOppfolgingstilfelleServiceV2: MotebehovOppfolgingstilfelleServiceV2,
     private val motebehovStatusService: MotebehovStatusService,
+    private val motebehovStatusServiceV2: MotebehovStatusServiceV2,
     private val brukertilgangService: BrukertilgangService,
     @Value("\${dialogmote.frontend.client.id}")
     val dialogmoteClientId: String,
     @Value("\${tokenx.idp}")
-    val dialogmoteTokenxIdp: String
+    val dialogmoteTokenxIdp: String,
+    @Value("\${use.kandidatlista}")
+    private val useKandidatlista: Boolean,
 ) {
     @GetMapping(
         value = ["/motebehov"],
@@ -47,6 +53,10 @@ class MotebehovArbeidsgiverV3Controller @Inject constructor(
 
         val arbeidsgiverFnr = fnrFromIdportenTokenX(contextHolder)
         val isOwnLeader = arbeidsgiverFnr.value == ansattFnr.value
+
+        if (useKandidatlista) {
+            return motebehovStatusServiceV2.motebehovStatusForArbeidsgiver(ansattFnr, isOwnLeader, virksomhetsnummer)
+        }
 
         return motebehovStatusService.motebehovStatusForArbeidsgiver(ansattFnr, isOwnLeader, virksomhetsnummer)
     }
@@ -68,11 +78,20 @@ class MotebehovArbeidsgiverV3Controller @Inject constructor(
         val arbeidsgiverFnr = fnrFromIdportenTokenX(contextHolder)
         val isOwnLeader = arbeidsgiverFnr.value == ansattFnr.value
 
-        motebehovOppfolgingstilfelleService.createMotehovForArbeidgiver(
-            innloggetFnr,
-            ansattFnr,
-            isOwnLeader,
-            nyttMotebehov
-        )
+        if (useKandidatlista) {
+            motebehovOppfolgingstilfelleServiceV2.createMotebehovForArbeidgiver(
+                innloggetFnr,
+                ansattFnr,
+                isOwnLeader,
+                nyttMotebehov
+            )
+        } else {
+            motebehovOppfolgingstilfelleService.createMotehovForArbeidgiver(
+                innloggetFnr,
+                ansattFnr,
+                isOwnLeader,
+                nyttMotebehov
+            )
+        }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidstakerV2Controller.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidstakerV2Controller.kt
@@ -33,7 +33,7 @@ class MotebehovArbeidstakerV2Controller @Inject constructor(
     private val motebehovOppfolgingstilfelleService: MotebehovOppfolgingstilfelleService,
     private val motebehovOppfolgingstilfelleServiceV2: MotebehovOppfolgingstilfelleServiceV2,
     private val brukertilgangService: BrukertilgangService,
-    @Value("\${use.kandidatlista}")
+    @Value("\${toggle.kandidatlista}")
     private val useKandidatlista: Boolean,
 ) {
     @GetMapping(

--- a/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidstakerV3Controller.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidstakerV3Controller.kt
@@ -8,9 +8,11 @@ import no.nav.syfo.api.auth.tokenX.TokenXUtil.fnrFromIdportenTokenX
 import no.nav.syfo.consumer.brukertilgang.BrukertilgangService
 import no.nav.syfo.metric.Metric
 import no.nav.syfo.motebehov.MotebehovOppfolgingstilfelleService
+import no.nav.syfo.motebehov.MotebehovOppfolgingstilfelleServiceV2
 import no.nav.syfo.motebehov.MotebehovSvar
 import no.nav.syfo.motebehov.motebehovstatus.MotebehovStatus
 import no.nav.syfo.motebehov.motebehovstatus.MotebehovStatusService
+import no.nav.syfo.motebehov.motebehovstatus.MotebehovStatusServiceV2
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.*
@@ -24,14 +26,18 @@ class MotebehovArbeidstakerV3Controller @Inject constructor(
     private val contextHolder: TokenValidationContextHolder,
     private val metric: Metric,
     private val motebehovStatusService: MotebehovStatusService,
+    private val motebehovStatusServiceV2: MotebehovStatusServiceV2,
     private val motebehovOppfolgingstilfelleService: MotebehovOppfolgingstilfelleService,
+    private val motebehovOppfolgingstilfelleServiceV2: MotebehovOppfolgingstilfelleServiceV2,
     private val brukertilgangService: BrukertilgangService,
     @Value("\${dialogmote.frontend.client.id}")
     val dialogmoteClientId: String,
     @Value("\${ditt.sykefravaer.frontend.client.id}")
     val dittSykefravaerClientId: String,
     @Value("\${tokenx.idp}")
-    val dialogmoteTokenxIdp: String
+    val dialogmoteTokenxIdp: String,
+    @Value("\${use.kandidatlista}")
+    private val useKandidatlista: Boolean,
 ) {
     @GetMapping(
         value = ["/motebehov"],
@@ -49,6 +55,11 @@ class MotebehovArbeidstakerV3Controller @Inject constructor(
         brukertilgangService.kastExceptionHvisIkkeTilgangTilSegSelv(arbeidstakerFnr.value)
 
         metric.tellEndepunktKall("call_endpoint_motebehovstatus_arbeidstaker")
+
+        if (useKandidatlista) {
+            return motebehovStatusServiceV2.motebehovStatusForArbeidstaker(arbeidstakerFnr)
+        }
+
         return motebehovStatusService.motebehovStatusForArbeidstaker(arbeidstakerFnr)
     }
 
@@ -70,9 +81,16 @@ class MotebehovArbeidstakerV3Controller @Inject constructor(
 
         brukertilgangService.kastExceptionHvisIkkeTilgangTilSegSelv(arbeidstakerFnr.value)
 
-        motebehovOppfolgingstilfelleService.createMotehovForArbeidstaker(
-            arbeidstakerFnr,
-            nyttMotebehovSvar
-        )
+        if (useKandidatlista) {
+            motebehovOppfolgingstilfelleServiceV2.createMotebehovForArbeidstaker(
+                arbeidstakerFnr,
+                nyttMotebehovSvar
+            )
+        } else {
+            motebehovOppfolgingstilfelleService.createMotehovForArbeidstaker(
+                arbeidstakerFnr,
+                nyttMotebehovSvar
+            )
+        }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidstakerV3Controller.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidstakerV3Controller.kt
@@ -36,7 +36,7 @@ class MotebehovArbeidstakerV3Controller @Inject constructor(
     val dittSykefravaerClientId: String,
     @Value("\${tokenx.idp}")
     val dialogmoteTokenxIdp: String,
-    @Value("\${use.kandidatlista}")
+    @Value("\${toggle.kandidatlista}")
     private val useKandidatlista: Boolean,
 ) {
     @GetMapping(

--- a/src/main/kotlin/no/nav/syfo/motebehov/motebehovstatus/MotebehovStatus.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/motebehovstatus/MotebehovStatus.kt
@@ -22,3 +22,9 @@ fun MotebehovStatus.isSvarBehovVarselAvailable(newestMotebehov: Motebehov): Bool
         this.motebehov == null &&
         !newestMotebehov.isUbehandlet()
 }
+
+fun MotebehovStatus.isMotebehovAvailableForAnswer(): Boolean {
+    return this.visMotebehov &&
+        this.skjemaType != null &&
+        this.motebehov == null
+}

--- a/src/main/kotlin/no/nav/syfo/motebehov/motebehovstatus/MotebehovStatusServiceV2.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/motebehovstatus/MotebehovStatusServiceV2.kt
@@ -1,0 +1,135 @@
+package no.nav.syfo.motebehov.motebehovstatus
+
+import no.nav.syfo.consumer.aktorregister.domain.Fodselsnummer
+import no.nav.syfo.dialogmote.DialogmoteStatusService
+import no.nav.syfo.dialogmotekandidat.DialogmotekandidatService
+import no.nav.syfo.motebehov.*
+import no.nav.syfo.oppfolgingstilfelle.OppfolgingstilfelleService
+import no.nav.syfo.oppfolgingstilfelle.database.PersonOppfolgingstilfelle
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+import javax.inject.Inject
+
+@Service
+class MotebehovStatusServiceV2 @Inject constructor(
+    private val motebehovService: MotebehovService,
+    private val dialogmotekandidatService: DialogmotekandidatService,
+    private val dialogmoteStatusService: DialogmoteStatusService,
+    private val oppfolgingstilfelleService: OppfolgingstilfelleService
+) {
+
+    fun motebehovStatusForArbeidstaker(
+        arbeidstakerFnr: Fodselsnummer
+    ): MotebehovStatus {
+        LOG.info("Henter møtebehovstatus for arbeidstaker")
+
+        val hasUpcomingDialogmote: Boolean =
+            dialogmoteStatusService.isDialogmotePlanlagtEtterDato(arbeidstakerFnr, null, LocalDate.now())
+        val oppfolgingstilfelle =
+            oppfolgingstilfelleService.getActiveOppfolgingstilfelleForArbeidstaker(arbeidstakerFnr)
+        val motebehovList: List<Motebehov> =
+            motebehovService.hentMotebehovListeForOgOpprettetAvArbeidstaker(arbeidstakerFnr)
+        val isDialogmoteKandidat: Boolean =
+            dialogmotekandidatService.getDialogmotekandidatStatus(arbeidstakerFnr)?.kandidat == true
+
+        return motebehovStatus(hasUpcomingDialogmote, oppfolgingstilfelle, isDialogmoteKandidat, motebehovList)
+    }
+
+    fun motebehovStatusForArbeidsgiver(
+        arbeidstakerFnr: Fodselsnummer,
+        isOwnLeader: Boolean,
+        virksomhetsnummer: String
+    ): MotebehovStatus {
+        LOG.info("Henter møtebehovstatus for arbeidsgiver")
+
+        val hasUpcomingDialogmote: Boolean =
+            dialogmoteStatusService.isDialogmotePlanlagtEtterDato(arbeidstakerFnr, virksomhetsnummer, LocalDate.now())
+        val oppfolgingstilfelle =
+            oppfolgingstilfelleService.getActiveOppfolgingstilfelleForArbeidsgiver(arbeidstakerFnr, virksomhetsnummer)
+        val isDialogmoteKandidat: Boolean =
+            dialogmotekandidatService.getDialogmotekandidatStatus(arbeidstakerFnr)?.kandidat == true
+        val motebehovList =
+            motebehovService.hentMotebehovListeForArbeidstakerOpprettetAvLeder(
+                arbeidstakerFnr,
+                isOwnLeader,
+                virksomhetsnummer
+            )
+
+        return motebehovStatus(hasUpcomingDialogmote, oppfolgingstilfelle, isDialogmoteKandidat, motebehovList)
+    }
+
+    fun motebehovStatus(
+        hasUpcomingDialogmote: Boolean,
+        oppfolgingstilfelle: PersonOppfolgingstilfelle?,
+        isDialogmoteKandidat: Boolean,
+        motebehovList: List<Motebehov>
+    ): MotebehovStatus {
+        if (hasUpcomingDialogmote || oppfolgingstilfelle == null) {
+            return MotebehovStatus(
+                false,
+                null,
+                null,
+            )
+        } else if (isDialogmoteKandidat) {
+            return MotebehovStatus(
+                true,
+                MotebehovSkjemaType.SVAR_BEHOV,
+                getNewestSvarBehovMotebehovInOppfolgingstilfelle(oppfolgingstilfelle, motebehovList)
+            )
+        } else {
+            return MotebehovStatus(
+                true,
+                MotebehovSkjemaType.MELD_BEHOV,
+                getNewestMeldBehovMotebehovInOppfolgingstilfelle(oppfolgingstilfelle, motebehovList)
+            )
+        }
+    }
+
+    private fun getNewestSvarBehovMotebehovInOppfolgingstilfelle(
+        oppfolgingstilfelle: PersonOppfolgingstilfelle,
+        motebehovList: List<Motebehov>
+    ): Motebehov? {
+        getNewestMotebehovInOppfolgingstilfelle(
+            oppfolgingstilfelle,
+            motebehovList
+        )?.let {
+            if (it.isSvarBehovForOppfolgingstilfelle(oppfolgingstilfelle) || it.isUbehandlet()) {
+                return it
+            }
+        }
+        return null
+    }
+
+    private fun getNewestMeldBehovMotebehovInOppfolgingstilfelle(
+        oppfolgingstilfelle: PersonOppfolgingstilfelle,
+        motebehovList: List<Motebehov>
+    ): Motebehov? {
+        getNewestMotebehovInOppfolgingstilfelle(
+            oppfolgingstilfelle,
+            motebehovList
+        )?.let {
+            if (it.isUbehandlet()) {
+                return it
+            }
+        }
+        return null
+    }
+
+    fun getNewestMotebehovInOppfolgingstilfelle(
+        oppfolgingstilfelle: PersonOppfolgingstilfelle,
+        motebehovList: List<Motebehov>
+    ): Motebehov? {
+        val motebehovListCreatedInOppfolgingstilfelle =
+            motebehovList.filter { it.isCreatedInOppfolgingstilfelle(oppfolgingstilfelle) }
+        return if (motebehovListCreatedInOppfolgingstilfelle.isNotEmpty()) {
+            motebehovListCreatedInOppfolgingstilfelle.first()
+        } else {
+            null
+        }
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(MotebehovStatusServiceV2::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/motebehov/motebehovstatus/MotebehovStatusServiceV2.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/motebehovstatus/MotebehovStatusServiceV2.kt
@@ -6,7 +6,6 @@ import no.nav.syfo.dialogmotekandidat.DialogmotekandidatService
 import no.nav.syfo.motebehov.*
 import no.nav.syfo.oppfolgingstilfelle.OppfolgingstilfelleService
 import no.nav.syfo.oppfolgingstilfelle.database.PersonOppfolgingstilfelle
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import javax.inject.Inject
@@ -22,8 +21,6 @@ class MotebehovStatusServiceV2 @Inject constructor(
     fun motebehovStatusForArbeidstaker(
         arbeidstakerFnr: Fodselsnummer
     ): MotebehovStatus {
-        LOG.info("Henter møtebehovstatus for arbeidstaker")
-
         val hasUpcomingDialogmote: Boolean =
             dialogmoteStatusService.isDialogmotePlanlagtEtterDato(arbeidstakerFnr, null, LocalDate.now())
         val oppfolgingstilfelle =
@@ -41,8 +38,6 @@ class MotebehovStatusServiceV2 @Inject constructor(
         isOwnLeader: Boolean,
         virksomhetsnummer: String
     ): MotebehovStatus {
-        LOG.info("Henter møtebehovstatus for arbeidsgiver")
-
         val hasUpcomingDialogmote: Boolean =
             dialogmoteStatusService.isDialogmotePlanlagtEtterDato(arbeidstakerFnr, virksomhetsnummer, LocalDate.now())
         val oppfolgingstilfelle =
@@ -127,9 +122,5 @@ class MotebehovStatusServiceV2 @Inject constructor(
         } else {
             null
         }
-    }
-
-    companion object {
-        private val LOG = LoggerFactory.getLogger(MotebehovStatusServiceV2::class.java)
     }
 }

--- a/src/main/kotlin/no/nav/syfo/varsel/VarselServiceV2.kt
+++ b/src/main/kotlin/no/nav/syfo/varsel/VarselServiceV2.kt
@@ -1,0 +1,140 @@
+package no.nav.syfo.varsel
+
+import no.nav.syfo.consumer.aktorregister.AktorregisterConsumer
+import no.nav.syfo.consumer.aktorregister.domain.AktorId
+import no.nav.syfo.consumer.aktorregister.domain.Fodselsnummer
+import no.nav.syfo.consumer.esyfovarsel.EsyfovarselConsumer
+import no.nav.syfo.dialogmote.DialogmoteStatusService
+import no.nav.syfo.dialogmotekandidat.DialogmotekandidatService
+import no.nav.syfo.metric.Metric
+import no.nav.syfo.motebehov.Motebehov
+import no.nav.syfo.motebehov.MotebehovService
+import no.nav.syfo.motebehov.motebehovstatus.MotebehovStatusServiceV2
+import no.nav.syfo.motebehov.motebehovstatus.isSvarBehovVarselAvailable
+import no.nav.syfo.oppfolgingstilfelle.OppfolgingstilfelleService
+import no.nav.syfo.oppfolgingstilfelle.database.PersonOppfolgingstilfelle
+import no.nav.syfo.varsel.esyfovarsel.EsyfovarselService
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+import javax.inject.Inject
+
+@Service
+class VarselServiceV2 @Inject constructor(
+    private val metric: Metric,
+    private val aktorregisterConsumer: AktorregisterConsumer,
+    private val esyfovarselConsumer: EsyfovarselConsumer,
+    private val motebehovService: MotebehovService,
+    private val motebehovStatusServiceV2: MotebehovStatusServiceV2,
+    private val oppfolgingstilfelleService: OppfolgingstilfelleService,
+    private val esyfovarselService: EsyfovarselService,
+    private val dialogmoteStatusService: DialogmoteStatusService,
+    private val dialogmotekandidatService: DialogmotekandidatService
+) {
+    fun sendVarselTilNaermesteLeder(motebehovsvarVarselInfo: MotebehovsvarVarselInfo) {
+        val arbeidstakerFnr = aktorregisterConsumer.getFnrForAktorId(AktorId(motebehovsvarVarselInfo.sykmeldtAktorId))
+        val isDialogmoteAlleredePlanlagt = dialogmoteStatusService.isDialogmotePlanlagtEtterDato(
+            Fodselsnummer(arbeidstakerFnr),
+            motebehovsvarVarselInfo.orgnummer, LocalDate.now()
+        )
+
+        if (!isDialogmoteAlleredePlanlagt) {
+            val isSvarBehovVarselAvailableForLeder = isSvarBehovVarselAvailableArbeidsgiver(
+                Fodselsnummer(arbeidstakerFnr),
+                motebehovsvarVarselInfo.orgnummer
+            )
+            if (isSvarBehovVarselAvailableForLeder) {
+                metric.tellHendelse("varsel_leder_sent")
+                esyfovarselService.sendSvarMotebehovVarselTilNarmesteLeder(
+                    motebehovsvarVarselInfo.naermesteLederFnr,
+                    motebehovsvarVarselInfo.arbeidstakerFnr,
+                    motebehovsvarVarselInfo.orgnummer
+                )
+            } else {
+                metric.tellHendelse("varsel_leder_not_sent_motebehov_not_available")
+                log.info("Not sending Varsel to Narmeste Leder because Møtebehov is not available for the combination of Arbeidstaker and Virksomhet")
+            }
+        } else {
+            metric.tellHendelse("varsel_leder_not_sent_mote_allerede_planlagt")
+            log.info("Not sending Varsel to Narmeste Leder because dialogmote er planlagt")
+        }
+    }
+
+    fun sendVarselTilArbeidstaker(motebehovsvarVarselInfo: MotebehovsvarSykmeldtVarselInfo) {
+        val isDialogmoteAlleredePlanlagt = dialogmoteStatusService.isDialogmotePlanlagtEtterDato(
+            Fodselsnummer(motebehovsvarVarselInfo.arbeidstakerFnr),
+            motebehovsvarVarselInfo.orgnummer, LocalDate.now()
+        )
+
+        if (!isDialogmoteAlleredePlanlagt) {
+            val isSvarBehovVarselAvailableForArbeidstaker = isSvarBehovVarselAvailableArbeidstaker(
+                Fodselsnummer(motebehovsvarVarselInfo.arbeidstakerFnr),
+            )
+            if (isSvarBehovVarselAvailableForArbeidstaker) {
+                metric.tellHendelse("varsel_arbeidstaker_sent")
+                esyfovarselService.sendSvarMotebehovVarselTilArbeidstaker(motebehovsvarVarselInfo.arbeidstakerFnr)
+            } else {
+                metric.tellHendelse("varsel_arbeidstaker_not_sent_motebehov_not_available")
+                log.info("Not sending Varsel to Arbeidstaker because Møtebehov is not available for the combination of Arbeidstaker and Virksomhet")
+            }
+        } else {
+            metric.tellHendelse("varsel_arbeidstaker_not_sent_mote_allerede_planlagt")
+            log.info("Not sending Varsel to Arbeidstaker because dialogmote er planlagt")
+        }
+    }
+
+    fun isSvarBehovVarselAvailableArbeidstaker(arbeidstakerFnr: Fodselsnummer): Boolean {
+        return isSvarBehovVarselAvailable(
+            motebehovService.hentMotebehovListeForOgOpprettetAvArbeidstaker(arbeidstakerFnr),
+            oppfolgingstilfelleService.getActiveOppfolgingstilfelleForArbeidstaker(arbeidstakerFnr),
+            dialogmotekandidatService.getDialogmotekandidatStatus(arbeidstakerFnr)?.kandidat == true
+        )
+    }
+
+    fun isSvarBehovVarselAvailableArbeidsgiver(
+        arbeidstakerFnr: Fodselsnummer,
+        virksomhetsnummer: String
+    ): Boolean {
+        return isSvarBehovVarselAvailable(
+            motebehovService.hentMotebehovListeForArbeidstakerOpprettetAvLeder(
+                arbeidstakerFnr,
+                false,
+                virksomhetsnummer
+            ),
+            oppfolgingstilfelleService.getActiveOppfolgingstilfelleForArbeidsgiver(arbeidstakerFnr, virksomhetsnummer),
+            dialogmotekandidatService.getDialogmotekandidatStatus(arbeidstakerFnr)?.kandidat == true
+        )
+    }
+
+    fun has39UkerVarselBeenSent(
+        arbeidtakerFnr: Fodselsnummer
+    ): Boolean {
+        val aktorId = aktorregisterConsumer.getAktorIdForFodselsnummer(arbeidtakerFnr)
+        return esyfovarselConsumer.varsel39Sent(aktorId)
+    }
+
+    private fun isSvarBehovVarselAvailable(
+        motebehovList: List<Motebehov>,
+        oppfolgingstilfelle: PersonOppfolgingstilfelle?,
+        isDialogmoteKandidat: Boolean,
+    ): Boolean {
+        oppfolgingstilfelle?.let {
+            val motebehovStatus = motebehovStatusServiceV2.motebehovStatus(
+                false,
+                oppfolgingstilfelle,
+                isDialogmoteKandidat,
+                motebehovList
+            )
+
+            return motebehovStatusServiceV2.getNewestMotebehovInOppfolgingstilfelle(oppfolgingstilfelle, motebehovList)
+                ?.let { newestMotebehov ->
+                    return motebehovStatus.isSvarBehovVarselAvailable(newestMotebehov)
+                } ?: motebehovStatus.isSvarBehovVarselAvailable()
+        }
+        return false
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(VarselServiceV2::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/varsel/api/EsyfovarselController.kt
+++ b/src/main/kotlin/no/nav/syfo/varsel/api/EsyfovarselController.kt
@@ -6,6 +6,8 @@ import no.nav.syfo.api.auth.OIDCIssuer.EKSTERN
 import no.nav.syfo.api.auth.OIDCUtil
 import no.nav.syfo.consumer.brukertilgang.BrukertilgangService
 import no.nav.syfo.varsel.VarselService
+import no.nav.syfo.varsel.VarselServiceV2
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -19,7 +21,10 @@ class EsyfovarselController @Inject constructor(
     private val contextHolder: TokenValidationContextHolder,
     private val metric: no.nav.syfo.metric.Metric,
     private val varselService: VarselService,
-    private val brukertilgangService: BrukertilgangService
+    private val varselServiceV2: VarselServiceV2,
+    private val brukertilgangService: BrukertilgangService,
+    @Value("\${use.kandidatlista}")
+    private val useKandidatlista: Boolean,
 ) {
     @GetMapping(
         value = ["/39uker"],
@@ -30,6 +35,11 @@ class EsyfovarselController @Inject constructor(
         brukertilgangService.kastExceptionHvisIkkeTilgang(fnr.value)
 
         metric.tellEndepunktKall("call_endpoint_esyfovarsel_39uker")
+
+        if (useKandidatlista) {
+            return varselServiceV2.has39UkerVarselBeenSent(fnr)
+        }
+
         return varselService.has39UkerVarselBeenSent(fnr)
     }
 }

--- a/src/main/kotlin/no/nav/syfo/varsel/api/EsyfovarselController.kt
+++ b/src/main/kotlin/no/nav/syfo/varsel/api/EsyfovarselController.kt
@@ -23,7 +23,7 @@ class EsyfovarselController @Inject constructor(
     private val varselService: VarselService,
     private val varselServiceV2: VarselServiceV2,
     private val brukertilgangService: BrukertilgangService,
-    @Value("\${use.kandidatlista}")
+    @Value("\${toggle.kandidatlista}")
     private val useKandidatlista: Boolean,
 ) {
     @GetMapping(

--- a/src/test/kotlin/no/nav/syfo/dialogmotekandidat/DialogmotekandidatServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmotekandidat/DialogmotekandidatServiceTest.kt
@@ -6,7 +6,7 @@ import no.nav.syfo.dialogmotekandidat.database.DialogmotekandidatDAO
 import no.nav.syfo.dialogmotekandidat.database.DialogmotekandidatEndringArsak
 import no.nav.syfo.dialogmotekandidat.kafka.KafkaDialogmotekandidatEndring
 import no.nav.syfo.testhelper.UserConstants
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -59,7 +59,7 @@ internal class DialogmotekandidatServiceTest {
             Fodselsnummer(UserConstants.ARBEIDSTAKER_FNR)
         )
 
-        Assertions.assertThat(existingKandidat).isNull()
+        assertThat(existingKandidat).isNull()
 
         dialogmotekandidatService.receiveDialogmotekandidatEndring(
             generateDialogmotekandidatEndring(
@@ -73,11 +73,11 @@ internal class DialogmotekandidatServiceTest {
             Fodselsnummer(UserConstants.ARBEIDSTAKER_FNR)
         )
 
-        Assertions.assertThat(kandidatAfterKafkaMessage).isNotNull
-        Assertions.assertThat(kandidatAfterKafkaMessage?.databaseUpdatedAt).isNotNull
-        Assertions.assertThat(kandidatAfterKafkaMessage?.personIdentNumber).isEqualTo(UserConstants.ARBEIDSTAKER_FNR)
-        Assertions.assertThat(kandidatAfterKafkaMessage?.kandidat).isTrue
-        Assertions.assertThat(kandidatAfterKafkaMessage?.arsak).isEqualTo(DialogmotekandidatEndringArsak.STOPPUNKT)
+        assertThat(kandidatAfterKafkaMessage).isNotNull
+        assertThat(kandidatAfterKafkaMessage?.databaseUpdatedAt).isNotNull
+        assertThat(kandidatAfterKafkaMessage?.personIdentNumber).isEqualTo(UserConstants.ARBEIDSTAKER_FNR)
+        assertThat(kandidatAfterKafkaMessage?.kandidat).isTrue
+        assertThat(kandidatAfterKafkaMessage?.arsak).isEqualTo(DialogmotekandidatEndringArsak.STOPPUNKT)
     }
 
     @Test
@@ -94,9 +94,9 @@ internal class DialogmotekandidatServiceTest {
             Fodselsnummer(UserConstants.ARBEIDSTAKER_FNR)
         )
 
-        Assertions.assertThat(existingKandidat).isNotNull
-        Assertions.assertThat(existingKandidat?.kandidat).isTrue
-        Assertions.assertThat(existingKandidat?.arsak).isEqualTo(DialogmotekandidatEndringArsak.STOPPUNKT)
+        assertThat(existingKandidat).isNotNull
+        assertThat(existingKandidat?.kandidat).isTrue
+        assertThat(existingKandidat?.arsak).isEqualTo(DialogmotekandidatEndringArsak.STOPPUNKT)
 
         dialogmotekandidatService.receiveDialogmotekandidatEndring(
             generateDialogmotekandidatEndring(
@@ -110,9 +110,9 @@ internal class DialogmotekandidatServiceTest {
             Fodselsnummer(UserConstants.ARBEIDSTAKER_FNR)
         )
 
-        Assertions.assertThat(updatedKandidat).isNotNull
-        Assertions.assertThat(updatedKandidat?.kandidat).isFalse
-        Assertions.assertThat(updatedKandidat?.arsak).isEqualTo(DialogmotekandidatEndringArsak.UNNTAK)
+        assertThat(updatedKandidat).isNotNull
+        assertThat(updatedKandidat?.kandidat).isFalse
+        assertThat(updatedKandidat?.arsak).isEqualTo(DialogmotekandidatEndringArsak.UNNTAK)
     }
 
     @Test
@@ -143,8 +143,8 @@ internal class DialogmotekandidatServiceTest {
         )
 
         // Nyeste melding er den som har blitt persistert
-        Assertions.assertThat(kandidatStatus).isNotNull
-        Assertions.assertThat(kandidatStatus?.kandidat).isFalse
-        Assertions.assertThat(kandidatStatus?.arsak).isEqualTo(DialogmotekandidatEndringArsak.DIALOGMOTE_FERDIGSTILT)
+        assertThat(kandidatStatus).isNotNull
+        assertThat(kandidatStatus?.kandidat).isFalse
+        assertThat(kandidatStatus?.arsak).isEqualTo(DialogmotekandidatEndringArsak.DIALOGMOTE_FERDIGSTILT)
     }
 }

--- a/src/test/kotlin/no/nav/syfo/motebehov/motebehovstatus/MotebehovStatusServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/motebehov/motebehovstatus/MotebehovStatusServiceTest.kt
@@ -1,0 +1,106 @@
+package no.nav.syfo.motebehov.motebehovstatus
+
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import no.nav.syfo.LocalApplication
+import no.nav.syfo.consumer.aktorregister.domain.Fodselsnummer
+import no.nav.syfo.dialogmote.DialogmoteStatusService
+import no.nav.syfo.dialogmotekandidat.DialogmotekandidatService
+import no.nav.syfo.dialogmotekandidat.database.DialogmoteKandidatEndring
+import no.nav.syfo.dialogmotekandidat.database.DialogmotekandidatEndringArsak
+import no.nav.syfo.motebehov.MotebehovService
+import no.nav.syfo.oppfolgingstilfelle.OppfolgingstilfelleService
+import no.nav.syfo.oppfolgingstilfelle.database.PersonOppfolgingstilfelle
+import no.nav.syfo.testhelper.UserConstants
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.*
+
+@ExtendWith(SpringExtension::class)
+@SpringBootTest(classes = [LocalApplication::class])
+@DirtiesContext
+class MotebehovStatusServiceTest {
+
+    @MockkBean
+    private lateinit var motebehovService: MotebehovService
+
+    @MockkBean
+    private lateinit var dialogmotekandidatService: DialogmotekandidatService
+
+    @MockkBean
+    private lateinit var dialogmoteStatusService: DialogmoteStatusService
+
+    @MockkBean
+    private lateinit var oppfolgingstilfelleService: OppfolgingstilfelleService
+
+    @Autowired
+    private lateinit var motebehovStatusServiceV2: MotebehovStatusServiceV2
+
+    private val userFnr = Fodselsnummer(UserConstants.ARBEIDSTAKER_FNR)
+
+    @Test
+    fun kandidatWithNoDialogmoteGivesStatusSvarBehov() {
+        every { dialogmoteStatusService.isDialogmotePlanlagtEtterDato(userFnr, null, any()) } returns false
+        every { oppfolgingstilfelleService.getActiveOppfolgingstilfelleForArbeidstaker(userFnr) } returns createOppfolgingstilfelle()
+        every { motebehovService.hentMotebehovListeForOgOpprettetAvArbeidstaker(userFnr) } returns emptyList()
+        every { dialogmotekandidatService.getDialogmotekandidatStatus(userFnr) } returns createDialogmoteKandidatEndring()
+
+        val motebehovStatusForArbeidstaker =
+            motebehovStatusServiceV2.motebehovStatusForArbeidstaker(userFnr)
+
+        assertThat(motebehovStatusForArbeidstaker.skjemaType).isEqualTo(MotebehovSkjemaType.SVAR_BEHOV)
+    }
+
+    @Test
+    fun kandidatWithDialogmoteGivesNoMotebehov() {
+        every { dialogmoteStatusService.isDialogmotePlanlagtEtterDato(userFnr, null, any()) } returns true
+        every { oppfolgingstilfelleService.getActiveOppfolgingstilfelleForArbeidstaker(userFnr) } returns createOppfolgingstilfelle()
+        every { motebehovService.hentMotebehovListeForOgOpprettetAvArbeidstaker(userFnr) } returns emptyList()
+        every { dialogmotekandidatService.getDialogmotekandidatStatus(userFnr) } returns createDialogmoteKandidatEndring()
+
+        val motebehovStatusForArbeidstaker =
+            motebehovStatusServiceV2.motebehovStatusForArbeidstaker(userFnr)
+
+        assertThat(motebehovStatusForArbeidstaker.skjemaType).isNull()
+    }
+
+    @Test
+    fun noDialogmoteAndNoKandidatGivesMeldBehov() {
+        every { dialogmoteStatusService.isDialogmotePlanlagtEtterDato(userFnr, null, any()) } returns false
+        every { oppfolgingstilfelleService.getActiveOppfolgingstilfelleForArbeidstaker(userFnr) } returns createOppfolgingstilfelle()
+        every { motebehovService.hentMotebehovListeForOgOpprettetAvArbeidstaker(userFnr) } returns emptyList()
+        every { dialogmotekandidatService.getDialogmotekandidatStatus(userFnr) } returns null
+
+        val motebehovStatusForArbeidstaker =
+            motebehovStatusServiceV2.motebehovStatusForArbeidstaker(userFnr)
+
+        assertThat(motebehovStatusForArbeidstaker.skjemaType).isEqualTo(MotebehovSkjemaType.MELD_BEHOV)
+    }
+
+    private fun createOppfolgingstilfelle(): PersonOppfolgingstilfelle {
+        return PersonOppfolgingstilfelle(
+            userFnr,
+            LocalDate.now().minusWeeks(4),
+            LocalDate.now().minusMonths(2)
+        )
+    }
+
+    private fun createDialogmoteKandidatEndring(): DialogmoteKandidatEndring {
+        return DialogmoteKandidatEndring(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            UserConstants.ARBEIDSTAKER_FNR,
+            true,
+            DialogmotekandidatEndringArsak.STOPPUNKT,
+            LocalDateTime.now().minusMinutes(10),
+            LocalDateTime.now()
+        )
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -103,4 +103,4 @@ tokenx.idp: "idporten"
 token.x.well.known.url: "https://token-x-well-known-url"
 token.x.client.id: "tokenx-client-id"
 token.x.private.jwk: "tokenx-jwk"
-use.kandidatlista: true
+toggle.kandidatlista: true

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -103,3 +103,4 @@ tokenx.idp: "idporten"
 token.x.well.known.url: "https://token-x-well-known-url"
 token.x.client.id: "tokenx-client-id"
 token.x.private.jwk: "tokenx-jwk"
+use.kandidatlista: true


### PR DESCRIPTION
- Bruker nå kandidatliste-status for å bestemme møtebehov-status
- Laget bryter for å skru på ny løsning. Avskrudd i prod, frem til isyfo er klare.
- Gjenbrukt gammel oppfølgingstilfelle-logikk. Bør muligens byttes ut på sikt
- Skrevet om til mockk