### PR TITLE
Fast forward isoppfolgingstilfelle-topic, and consume from old source to avoid data loss

### DIFF
--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/IsOppfolgingstilfelleKafkaConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/IsOppfolgingstilfelleKafkaConfig.kt
@@ -15,11 +15,14 @@ import org.springframework.kafka.listener.ContainerProperties
 
 import org.apache.kafka.common.errors.SerializationException
 import org.apache.kafka.common.serialization.Deserializer
+import org.springframework.beans.factory.annotation.Value
 
 @EnableKafka
 @Configuration
 class KafkaIsOppfolgingstilfelleConfig(
-    private val kafkaAivenConfig: KafkaAivenConfig
+    private val kafkaAivenConfig: KafkaAivenConfig,
+    @Value("\${app.name}") private val appName: String,
+    @Value("\${kafka.env.name}") private val kafkaEnv: String,
 ) {
     @Bean
     fun isOppfolgingtilfelleConsumerFactory(): ConsumerFactory<String, KafkaOppfolgingstilfellePerson> {
@@ -33,6 +36,14 @@ class KafkaIsOppfolgingstilfelleConfig(
                 put(
                     ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
                     KafkaIsOppfolgingstilfelleDeserializer::class.java.canonicalName
+                )
+                put(
+                    ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
+                    "latest"
+                )
+                put(
+                    ConsumerConfig.GROUP_ID_CONFIG,
+                    "$appName-$kafkaEnv-isoppfolgingstilfelle"
                 )
             }
         }

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/OversikthendelseOppfolgingstilfelleListener.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/OversikthendelseOppfolgingstilfelleListener.kt
@@ -1,0 +1,59 @@
+package no.nav.syfo.oppfolgingstilfelle.kafka
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import no.nav.syfo.oppfolgingstilfelle.OppfolgingstilfelleService
+import no.nav.syfo.oppfolgingstilfelle.kafka.domain.KOversikthendelsetilfelle
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Component
+import java.io.IOException
+
+private val objectMapper = ObjectMapper()
+    .registerModule(JavaTimeModule())
+    .registerModule(
+        KotlinModule.Builder()
+            .build()
+    )
+    .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE, true)
+    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+
+@Profile("remote")
+@Component
+class OppfolgingstilfelleListener(
+    private val oppfolgingstilfelleService: OppfolgingstilfelleService
+) {
+
+    @KafkaListener(topics = [OVERSIKTHENDELSE_OPPFOLGINGSTILFELLE_TOPIC])
+    fun oppfolgingstilfellePekerListener(
+        consumerRecord: ConsumerRecord<String, String>,
+        acknowledgment: Acknowledgment
+    ) {
+        try {
+            val kOversikthendelsetilfelle: KOversikthendelsetilfelle = map(consumerRecord.value())
+            oppfolgingstilfelleService.receiveKOversikthendelsetilfelle(kOversikthendelsetilfelle)
+            acknowledgment.acknowledge()
+        } catch (e: JsonProcessingException) {
+            LOG.error("OppfolgingstilfellePekerListener: Kunne ikke deserialisere KOppfolgingstilfellePeker", e)
+        } catch (e: Exception) {
+            LOG.error("OppfolgingstilfellePekerListener: Uventet feil ved lesing av KOppfolgingstilfellePeker", e)
+        }
+    }
+
+    @Throws(IOException::class)
+    private fun map(string: String): KOversikthendelsetilfelle {
+        return objectMapper.readValue(string, KOversikthendelsetilfelle::class.java)
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(OppfolgingstilfelleListener::class.java)
+
+        private const val OVERSIKTHENDELSE_OPPFOLGINGSTILFELLE_TOPIC = "aapen-syfo-oversikthendelse-tilfelle-v1"
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/domain/KOversiktHendelsetilfelle.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/domain/KOversiktHendelsetilfelle.kt
@@ -1,0 +1,22 @@
+package no.nav.syfo.oppfolgingstilfelle.kafka.domain
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class KOversikthendelsetilfelle(
+    val fnr: String,
+    val navn: String,
+    val enhetId: String,
+    val virksomhetsnummer: String,
+    val virksomhetsnavn: String,
+    val gradert: Boolean,
+    val fom: LocalDate,
+    val tom: LocalDate,
+    val tidspunkt: LocalDateTime
+)
+
+fun KOversikthendelsetilfelle.previouslyProcessed(
+    lastUpdatedAt: LocalDateTime?
+) = lastUpdatedAt?.let { it ->
+    this.tidspunkt.isBefore(it)
+} ?: false


### PR DESCRIPTION
    Denne er for å spare litt tid: I stedet for å lese inn alle oppfølgingstilfelle fra isoppfolgingstilfelle-topic,
    så setter vi den til å lese fra 'latest' (siste record commitet til broker), ellers må vi lese gjennom 40000000 records
    som vil ta litt tid når vi må gjøre DB-kall for å unngå duplikater for hver record. For å unngå at vi taper data må vi
    aktivere den gamle topicen i mellomtiden, som leser inn alt mellom 28/09 kl 14:54.,  til vi deployer denne branchen.