### PR TITLE
Support Node16 GitHub actions

### DIFF
--- a/.github/workflows/deploy-preprod.yaml
+++ b/.github/workflows/deploy-preprod.yaml
@@ -41,7 +41,7 @@ jobs:
         run: |
           ./gradlew shadowJar -x test
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@ab80d026d4753220c4243394c07c7d80f9638d06 # Use commit-sha1 instead of tag for security concerns
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/deploy-preprod.yaml
+++ b/.github/workflows/deploy-preprod.yaml
@@ -16,6 +16,7 @@ jobs:
       - name: Setup java
         uses: actions/setup-java@v3
         with:
+          distribution: adopt
           java-version: '11.x'
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-preprod.yaml
+++ b/.github/workflows/deploy-preprod.yaml
@@ -14,12 +14,12 @@ jobs:
       ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Setup java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: '11.x'
       - name: Checkout code
-        uses: actions/checkout@v1
-      - uses: actions/cache@v1
+        uses: actions/checkout@v3
+      - uses: actions/cache@v3
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-cache-${{ hashFiles('build.gradle.kts') }}
@@ -57,7 +57,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           ./gradlew shadowJar -x test
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@ab80d026d4753220c4243394c07c7d80f9638d06 # Use commit-sha1 instead of tag for security concerns
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,18 +14,18 @@ jobs:
       ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Setup java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: '11.x'
       - name: Checkout code
-        uses: actions/checkout@v1
-      - uses: actions/cache@v1
+        uses: actions/checkout@v3
+      - uses: actions/cache@v3
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-cache-${{ hashFiles('build.gradle.kts') }}
           restore-keys: |
             ${{ runner.os }}-gradle-cache-
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
@@ -58,7 +58,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
@@ -82,7 +82,7 @@ jobs:
     needs: deploy-dev
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,6 +16,7 @@ jobs:
       - name: Setup java
         uses: actions/setup-java@v3
         with:
+          distribution: adopt
           java-version: '11.x'
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Denne er for å fjerne warning som kommer på bygget:

```[Checkout code and create docker tag](https://github.com/navikt/syfomotebehov/actions/runs/3359437734/jobs/5567463382)
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/setup-java, actions/cache, actions/cache, docker/login-action, docker/login-action, actions/cache, actions/cache, actions/setup-java```