### PR TITLE
Legg til migreringsjob

### DIFF
--- a/naiserator-dev.yaml
+++ b/naiserator-dev.yaml
@@ -27,8 +27,8 @@ spec:
       cpu: 1000m
       memory: 1024Mi
   replicas:
-    min: 2
-    max: 4
+    min: 1
+    max: 1
     cpuThresholdPercentage: 80
   prometheus:
     enabled: true

--- a/naiserator-prod.yaml
+++ b/naiserator-prod.yaml
@@ -27,8 +27,8 @@ spec:
       cpu: 1000m
       memory: 1536Mi
   replicas:
-    min: 2
-    max: 4
+    min: 1
+    max: 1
     cpuThresholdPercentage: 80
   prometheus:
     enabled: true

--- a/src/main/kotlin/no/nav/syfo/migration/MigrateAktorIdComponent.kt
+++ b/src/main/kotlin/no/nav/syfo/migration/MigrateAktorIdComponent.kt
@@ -1,0 +1,38 @@
+package no.nav.syfo.migration
+
+import no.nav.syfo.consumer.pdl.PdlConsumer
+import no.nav.syfo.motebehov.database.MotebehovDAO
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class MigrateAktorIdComponent(
+    private val motebehovDAO: MotebehovDAO,
+    private val pdlConsumer: PdlConsumer
+) {
+    @Scheduled(cron = "*/5 * * * * *")
+    fun run() {
+        log.info("Running migration job")
+        val motebehovUtenFnr = motebehovDAO.hentMotebehovUtenFnr()
+
+        log.info("Antall rader uten fnr: ${motebehovUtenFnr.size}")
+
+        motebehovUtenFnr.forEach {
+            val uuid = it.uuid
+            val aktorIdSm = it.aktoerId
+            val aktorIdOpprettetAv = it.opprettetAv
+            val fnrSm = pdlConsumer.fnr(aktorIdSm)
+            val fnrOpprettetAv = pdlConsumer.fnr(aktorIdOpprettetAv)
+
+            if (motebehovDAO.oppdaterMotebehovMedSmFnr(uuid, fnrSm) == 0)
+                log.info("Klarte ikke oppdatere sykmeldt fnr for UUID $uuid")
+            if (motebehovDAO.oppdaterMotebehovMedOpprettetAvFnr(uuid, fnrOpprettetAv) == 0)
+                log.info("Klarte ikke oppdatere opprettet av fnr for UUID $uuid")
+        }
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(MigrateAktorIdComponent::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/migration/MigrateAktorIdComponent.kt
+++ b/src/main/kotlin/no/nav/syfo/migration/MigrateAktorIdComponent.kt
@@ -11,7 +11,7 @@ class MigrateAktorIdComponent(
     private val motebehovDAO: MotebehovDAO,
     private val pdlConsumer: PdlConsumer
 ) {
-    @Scheduled(cron = "*/5 * * * * *")
+    @Scheduled(cron = "*/30 * * * * *")
     fun run() {
         log.info("Running migration job")
         val motebehovUtenFnr = motebehovDAO.hentMotebehovUtenFnr()

--- a/src/main/kotlin/no/nav/syfo/migration/MigrateAktorIdComponent.kt
+++ b/src/main/kotlin/no/nav/syfo/migration/MigrateAktorIdComponent.kt
@@ -11,7 +11,7 @@ class MigrateAktorIdComponent(
     private val motebehovDAO: MotebehovDAO,
     private val pdlConsumer: PdlConsumer
 ) {
-    @Scheduled(cron = "*/30 * * * * *")
+    @Scheduled(cron = "0 0 21 * * *")
     fun run() {
         log.info("Running migration job")
         val motebehovUtenFnr = motebehovDAO.hentMotebehovUtenFnr()
@@ -30,6 +30,7 @@ class MigrateAktorIdComponent(
             if (motebehovDAO.oppdaterMotebehovMedOpprettetAvFnr(uuid, fnrOpprettetAv) == 0)
                 log.info("Klarte ikke oppdatere opprettet av fnr for UUID $uuid")
         }
+        log.info("Finished running migration job")
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/syfo/motebehov/database/MotebehovDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/database/MotebehovDAO.kt
@@ -23,6 +23,21 @@ import java.util.UUID
 @Transactional
 @Repository
 class MotebehovDAO(private val namedParameterJdbcTemplate: NamedParameterJdbcTemplate, private val jdbcTemplate: JdbcTemplate) {
+
+    fun hentMotebehovUtenFnr(): List<PMotebehov> {
+        return Optional.ofNullable(jdbcTemplate.query("SELECT * FROM motebehov WHERE sm_fnr is null OR opprettet_av_fnr is null", innsendingRowMapper)).orElse(emptyList())
+    }
+
+    fun oppdaterMotebehovMedSmFnr(uuid: UUID, smFnr: String): Int {
+        val oppdaterSql = "UPDATE motebehov SET sm_fnr = ? WHERE motebehov_uuid = ?"
+        return jdbcTemplate.update(oppdaterSql, smFnr, uuid.toString())
+    }
+
+    fun oppdaterMotebehovMedOpprettetAvFnr(uuid: UUID, opprettetAvFnr: String): Int {
+        val oppdaterSql = "UPDATE motebehov SET opprettet_av_fnr = ? WHERE motebehov_uuid = ?"
+        return jdbcTemplate.update(oppdaterSql, opprettetAvFnr, uuid.toString())
+    }
+
     fun hentMotebehovListeForAktoer(aktoerId: String): List<PMotebehov> {
         return Optional.ofNullable(jdbcTemplate.query("SELECT * FROM motebehov WHERE aktoer_id = ?", innsendingRowMapper, aktoerId)).orElse(emptyList())
     }


### PR DESCRIPTION
Migrate old rows from aktorid to fnr identifier. Setting nr. of replicas to 1, instead of having
to implement leader election to ensure that only one pod is running the job. Will be deployed
during off-work-hours to reduce traffic load from nav.no. The job may have to run several times
depending on inital result, but after all rows have been migrated, the code will be reverted.