### PR TITLE
Add new dialogmotekandidatendring-arsak

### DIFF
--- a/src/main/kotlin/no/nav/syfo/dialogmotekandidat/database/DialogmoteKandidatEndring.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmotekandidat/database/DialogmoteKandidatEndring.kt
@@ -17,4 +17,5 @@ enum class DialogmotekandidatEndringArsak {
     STOPPUNKT,
     DIALOGMOTE_FERDIGSTILT,
     UNNTAK,
+    LUKKET,
 }


### PR DESCRIPTION
Legger til ny årsak som skal brukes ved lukking av dialogmøtekandidater ifm høstdugnad :fallen_leaf: https://github.com/navikt/isdialogmotekandidat/pull/138