### PR TITLE
Ny årsak for dialogmøtekandidatendring: IKKE_AKTUELL

### DIFF
--- a/src/main/kotlin/no/nav/syfo/dialogmotekandidat/database/DialogmoteKandidatEndring.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmotekandidat/database/DialogmoteKandidatEndring.kt
@@ -18,5 +18,6 @@ enum class DialogmotekandidatEndringArsak {
     DIALOGMOTE_FERDIGSTILT,
     DIALOGMOTE_LUKKET,
     UNNTAK,
+    IKKE_AKTUELL,
     LUKKET,
 }

--- a/src/test/kotlin/no/nav/syfo/dialogmotekandidat/DialogmotekandidatServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmotekandidat/DialogmotekandidatServiceTest.kt
@@ -181,6 +181,32 @@ internal class DialogmotekandidatServiceTest {
     }
 
     @Test
+    fun skalIkkeSendeVarselDersomIkkeAktuellKandidat() {
+        val forsteGangKandidat = generateDialogmotekandidatEndring(
+            kandidat = false,
+            arsak = DialogmotekandidatEndringArsak.IKKE_AKTUELL.name,
+            OffsetDateTime.now(ZoneId.of("Europe/Oslo")).minusDays(10)
+        )
+
+        dialogmotekandidatService.receiveDialogmotekandidatEndring(forsteGangKandidat)
+
+        verify(exactly = 0) { varselServiceV2.sendSvarBehovVarsel(any(), any()) }
+    }
+
+    @Test
+    fun skalIkkeSendeVarselDersomLukketKandidat() {
+        val forsteGangKandidat = generateDialogmotekandidatEndring(
+            kandidat = false,
+            arsak = DialogmotekandidatEndringArsak.LUKKET.name,
+            OffsetDateTime.now(ZoneId.of("Europe/Oslo")).minusDays(10)
+        )
+
+        dialogmotekandidatService.receiveDialogmotekandidatEndring(forsteGangKandidat)
+
+        verify(exactly = 0) { varselServiceV2.sendSvarBehovVarsel(any(), any()) }
+    }
+
+    @Test
     fun skalFerdigsstilleVarselDersomIkkeKandidat() {
         val forsteGangKandidat = generateDialogmotekandidatEndring(
             kandidat = true,


### PR DESCRIPTION
Dialogmøtekandidater skal kunne settes om ikke-aktuelle (på samme måte som aktivitetskrav)