### PR TITLE
Fjerner deploy av drafts

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -1,6 +1,12 @@
 name: Build & Deploy
 on:
   push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Bruker samme trigger events på build workflow som andre repo. Kopiert fra esyfo-narmesteleder. 