### PR TITLE
Remove field with old name after dialogmote-frontend is using field with new name.

### DIFF
--- a/src/main/kotlin/no/nav/syfo/motebehov/motebehovstatus/MotebehovStatus.kt
+++ b/src/main/kotlin/no/nav/syfo/motebehov/motebehovstatus/MotebehovStatus.kt
@@ -35,7 +35,6 @@ fun MotebehovStatus.isMotebehovAvailableForAnswer(): Boolean {
 data class MotebehovStatusWithFormValuesDTO(
     val visMotebehov: Boolean,
     val skjemaType: MotebehovSkjemaType,
-    val motebehovWithFormValues: MotebehovWithFormValuesOutputDTO? = null,
     val motebehov: MotebehovWithFormValuesOutputDTO? = null,
 )
 

--- a/src/test/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidsgiverControllerV4Test.kt
+++ b/src/test/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidsgiverControllerV4Test.kt
@@ -599,7 +599,7 @@ class MotebehovArbeidsgiverControllerV4Test : IntegrationTest() {
 
         assertTrue(motebehovStatus.visMotebehov)
         assertEquals(MotebehovSkjemaType.SVAR_BEHOV, motebehovStatus.skjemaType)
-        val motebehov = motebehovStatus.motebehovWithFormValues!!
+        val motebehov = motebehovStatus.motebehov!!
         assertNotNull(motebehov)
         assertThat(motebehov.opprettetAv).isEqualTo(LEDER_AKTORID)
         assertThat(motebehov.arbeidstakerFnr).isEqualTo(ARBEIDSTAKER_FNR)

--- a/src/test/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidstakerControllerV4Test.kt
+++ b/src/test/kotlin/no/nav/syfo/motebehov/api/MotebehovArbeidstakerControllerV4Test.kt
@@ -564,7 +564,7 @@ class MotebehovArbeidstakerControllerV4Test : IntegrationTest() {
 
         assertTrue(motebehovStatus.visMotebehov)
         assertEquals(MotebehovSkjemaType.SVAR_BEHOV, motebehovStatus.skjemaType)
-        val motebehov = motebehovStatus.motebehovWithFormValues
+        val motebehov = motebehovStatus.motebehov
         assertNotNull(motebehov)
         assertThat(motebehov?.opprettetAv).isEqualTo(ARBEIDSTAKER_AKTORID)
         assertThat(motebehov?.arbeidstakerFnr).isEqualTo(ARBEIDSTAKER_FNR)

--- a/src/test/kotlin/no/nav/syfo/testhelper/assertion/MotebehovStatusAssertion.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/assertion/MotebehovStatusAssertion.kt
@@ -18,10 +18,10 @@ fun MotebehovStatusWithFormValuesDTO.assertMotebehovStatus(
     }
 
     if (expMotebehovFormValues != null) {
-        this.motebehovWithFormValues shouldNotBe null
-        this.motebehovWithFormValues!!.formValues shouldBe expMotebehovFormValues
-        this.motebehovWithFormValues!!.skjemaType shouldBe expSkjemaType
+        this.motebehov shouldNotBe null
+        this.motebehov?.formValues shouldBe expMotebehovFormValues
+        this.motebehov?.skjemaType shouldBe expSkjemaType
     } else {
-        this.motebehovWithFormValues shouldBe null
+        this.motebehov shouldBe null
     }
 }


### PR DESCRIPTION
Old field name: motebehovWithFormValues
New field name: motebehov