### PR TITLE
chore: revert kotlin version to 2.3.10

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,8 +29,8 @@ plugins {
     id("org.springframework.boot") version "4.0.5"
     id("io.spring.dependency-management") version "1.1.7"
     id("org.jlleitschuh.gradle.ktlint") version "14.2.0"
-    kotlin("jvm") version "2.3.20"
-    kotlin("plugin.spring") version "2.3.20"
+    kotlin("jvm") version "2.3.10"
+    kotlin("plugin.spring") version "2.3.10"
 }
 
 repositories {


### PR DESCRIPTION
Revert Kotlin version to 2.3.10